### PR TITLE
[TECHNICAL REQUEST] LPS-50578 Changing language is impossible on pages like terms_of_use

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
+++ b/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
@@ -724,7 +724,9 @@ public class PortalRequestProcessor extends TilesRequestProcessor {
 		if (!path.equals(_PATH_PORTAL_JSON_SERVICE) &&
 			!path.equals(_PATH_PORTAL_RENDER_PORTLET) &&
 			!ParamUtil.getBoolean(request, "wsrp") &&
-			!themeDisplay.isImpersonated()) {
+			!themeDisplay.isImpersonated() &&
+			!StringUtil.equalsIgnoreCase(
+				request.getMethod(), HttpMethods.POST)) {
 
 			// Authenticated users should agree to Terms of Use
 


### PR DESCRIPTION
Hi Tomáš,

We have a customer issue that on the "Terms of use" page, customer can not change language with the language portlet embedded in the theme. Actually, it's true at some other types of redirection to simple struts action type requests also, like the password reminder, password reset, etc.

The root cause is that if a user has not accepted the terms of use, PortalRequestProcessor.processPath method returns with _PATH_PORTAL_TERMS_OF_USE so the language portlet's ViewActon.processAction method will not be called.

I found out, that if request method is POST, we should not check that user was accepted the terms of use or not, it is enough to check it when the request method is GET, because after the POST we will redirect the browser, so it will come a GET and the terms_of_use page will be rendered. In this way, during the POST request, the language portlet's processAction method can run.

Zsigmond Rab and I were talking about this fix. First we were a bit scared, if we introduced some security risks and customers can somehow skip the Terms of use (and the other similar) pages, but we did not find anything suspicious.

I would like to ask you to check it, if it is an acceptable fix or not. We are opened to other fixing-ideas also.

If you want to test it, please read the Jira ticket also, because there are some other issues on trunk which prevent it to test.
The LPS for this pull request is: https://issues.liferay.com/browse/LPS-50578

First I sent it to Ray, because he is responsible for portal core, but Ray wrote me, that because our concern here is security, I should sent it to you.

Thank you in advance
Péter Borkuti
