### PR TITLE
[TECHNICAL-SUPPORT] LPS-50794 When LDAP export and e-mail verification is enabled verification e-mail is sent twice

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -4228,7 +4228,13 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		Company company = companyPersistence.findByPrimaryKey(
 			user.getCompanyId());
 
-		if (!company.isStrangersVerify()) {
+		if (company.isStrangersVerify() &&
+			!StringUtil.equalsIgnoreCase(
+				emailAddress1, user.getEmailAddress())) {
+
+			sendEmailAddressVerification(user, emailAddress1, serviceContext);
+		}
+		else {
 			setEmailAddress(
 				user, password, user.getFirstName(), user.getMiddleName(),
 				user.getLastName(), emailAddress1);
@@ -4240,9 +4246,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			contact.setEmailAddress(user.getEmailAddress());
 
 			contactPersistence.update(contact);
-		}
-		else if (!emailAddress1.equals(user.getEmailAddress())) {
-			sendEmailAddressVerification(user, emailAddress1, serviceContext);
 		}
 
 		return user;
@@ -5186,12 +5189,15 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		boolean sendEmailAddressVerification = false;
 
-		if (!company.isStrangersVerify()) {
+		if (company.isStrangersVerify() &&
+			!StringUtil.equalsIgnoreCase(
+				emailAddress, user.getEmailAddress())) {
+
+			sendEmailAddressVerification = true;
+		}
+		else {
 			setEmailAddress(
 				user, password, firstName, middleName, lastName, emailAddress);
-		}
-		else if (!emailAddress.equals(user.getEmailAddress())) {
-			sendEmailAddressVerification = true;
 		}
 
 		if (serviceContext != null) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-50794

Hi Tomáš,

The 2nd verification is triggered by an LDAP import, because when the user creates its account, it will be exported to LDAP and the modified date will be different than the one in the portal, so when the user attempts to login with the temp password (received in email), an LDAP import will be started and

``` java
    protected User importUser(
            long ldapServerId, long companyId, Attributes attributes,
            Properties userMappings, Properties userExpandoMappings,
            Properties contactMappings, Properties contactExpandoMappings,
            String password)
        throws Exception {
// ...
            String modifiedDate = LDAPUtil.getAttributeString(
                attributes, "modifyTimestamp");

            user = updateUser(
                companyId, ldapUser, user, userMappings, contactMappings,
                password, modifiedDate, isNew);
// ...
}
```

will hit

``` java
ULSI#sendEmailAddressVerification
```

, again.

Regards,
Tibor

/cc @NorbertKocsis
@topolik 

Final diff: https://github.com/lipusz/liferay-portal/compare/044bb769805c5ec1a19fc8104170c966151e1325...118c09c3634607df388ec4272cf72d977ada9ef2
