### PR TITLE
LPS-54599 CSRF token is included in URL when a form submission fails

### DIFF
--- a/portal-web/docroot/html/taglib/aui/form/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/start.jsp
@@ -16,9 +16,21 @@
 
 <%@ include file="/html/taglib/aui/form/init.jsp" %>
 
+<%
+String authToken = HttpUtil.getParameter(action, "p_auth", false);
+
+if (Validator.isNotNull(authToken)) {
+	action = HttpUtil.removeParameter(action, "p_auth");
+}
+%>
+
 <form action="<%= HtmlUtil.escape(action) %>" class="form <%= cssClass %> <%= inlineLabels ? "field-labels-inline" : StringPool.BLANK %>" data-fm-namespace="<%= namespace %>"  id="<%= namespace + name %>" method="<%= method %>" name="<%= namespace + name %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
 	<c:if test="<%= Validator.isNotNull(onSubmit) %>">
 		<fieldset class="input-container" disabled="disabled">
+	</c:if>
+
+	<c:if test="<%= Validator.isNotNull(authToken) %>">
+		<input name="p_auth" type="hidden" value="<%= authToken %>" />
 	</c:if>
 
 	<aui:input name="formDate" type="hidden" value="<%= System.currentTimeMillis() %>" />


### PR DESCRIPTION
In the case of a failed form submission sending a redirect would remove the form data.  So, instead I just move the token for forms.