### PR TITLE
[TECH-SUPPORT] LPS-55706 Failed login attempts not cleared on successful login

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -4677,7 +4677,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setLastLoginDate(lastLoginDate);
 		user.setLastLoginIP(lastLoginIP);
 
-		resetFailedLoginAttempts(user);
+		resetFailedLoginAttempts(user, true);
 
 		return user;
 	}
@@ -6205,9 +6205,15 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	protected void resetFailedLoginAttempts(User user) {
-		user.setFailedLoginAttempts(0);
+		resetFailedLoginAttempts(user, false);
+	}
 
-		userPersistence.update(user);
+	protected void resetFailedLoginAttempts(User user, boolean forceUpdate) {
+		if (forceUpdate || (user.getFailedLoginAttempts() > 0)) {
+			user.setFailedLoginAttempts(0);
+
+			userPersistence.update(user);
+		}
 	}
 
 	protected BaseModelSearchResult<User> searchUsers(


### PR DESCRIPTION
Hi Tomás,

Vilmos has found that his previous changes might cause DB level lock contention when failure count is re-set.

Thanks for reviewing!

Cheers,
László