### PR TITLE
[TECHNICAL-SUPPORT] LPS-58167 JAAS login doesn't work when LiberalScreenNameValidator enabled and user's screenName contains digits only

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/SecureFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/SecureFilter.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.auth.CompanyThreadLocal;
 import com.liferay.portal.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.security.jaas.JAASHelper;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.security.permission.PermissionThreadLocal;
@@ -37,6 +38,7 @@ import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.util.WebKeys;
 
 import java.util.HashSet;
@@ -274,7 +276,22 @@ public class SecureFilter extends BasePortalFilter {
 				_log.debug("Not securing " + completeURL);
 			}
 
-			User user = PortalUtil.getUser(request);
+			String remoteUser = request.getRemoteUser();
+
+			User user = null;
+
+			if (PropsValues.PORTAL_JAAS_ENABLE && (remoteUser != null)) {
+					long companyId = PortalUtil.getCompanyId(request);
+
+					long userId = JAASHelper.getJaasUserId(
+						companyId, remoteUser);
+
+					user = UserLocalServiceUtil.getUser(userId);
+			}
+			else {
+				user = PortalUtil.getUser(request);
+
+			}
 
 			if (user == null) {
 				user = PortalUtil.initUser(request);
@@ -308,12 +325,19 @@ public class SecureFilter extends BasePortalFilter {
 
 		User user = UserLocalServiceUtil.getUser(userId);
 
-		String userIdString = String.valueOf(userId);
+		String remoteUser = null;
 
-		request = new ProtectedServletRequest(request, userIdString, authType);
+		if (PropsValues.PORTAL_JAAS_ENABLE) {
+			remoteUser = request.getRemoteUser();
+		}
+		else {
+			remoteUser = String.valueOf(userId);
+		}
+
+		request = new ProtectedServletRequest(request, remoteUser, authType);
 
 		session.setAttribute(WebKeys.USER, user);
-		session.setAttribute(_AUTHENTICATED_USER, userIdString);
+		session.setAttribute(_AUTHENTICATED_USER, remoteUser);
 
 		initThreadLocals(request);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5567,7 +5567,7 @@ public class PortalImpl implements Portal {
 
 		long userId = getUserId(request);
 
-		if (userId <= 0) {
+		if ((userId <= 0) && !PropsValues.PORTAL_JAAS_ENABLE) {
 
 			// Portlet WARs may have the correct remote user and not have the
 			// correct user id because the user id is saved in the session and

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5567,7 +5567,7 @@ public class PortalImpl implements Portal {
 
 		long userId = getUserId(request);
 
-		if ((userId <= 0) && !PropsValues.PORTAL_JAAS_ENABLE) {
+		if (userId <= 0) {
 
 			// Portlet WARs may have the correct remote user and not have the
 			// correct user id because the user id is saved in the session and


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-58167

Hi Tomáš,

This is the fix for the issue we were discussing over Skype last week. I've tested the solution, and the necessary pre-and post-login events were executed and threadlocals were also populated correctly.

Quick summary of the technical background: https://issues.liferay.com/browse/LPS-58167?focusedCommentId=658167&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-658167

Let me know if you have any concerns, I'm open for starting a discussion about it, but I could not find a better way to fix it.

Thx,
Tibi