### PR TITLE
LPS-61285 Set session cookie to httpOnly=true by default (Servlet 3.0)

### DIFF
--- a/portal-web/docroot/WEB-INF/web.xml
+++ b/portal-web/docroot/WEB-INF/web.xml
@@ -767,6 +767,9 @@
 	</servlet-mapping>
 	<session-config>
 		<session-timeout>30</session-timeout>
+		<cookie-config>
+			<http-only>true</http-only>
+		</cookie-config>
 	</session-config>
 	<mime-mapping>
 		<extension>js</extension>

--- a/portal-web/docroot/WEB-INF/web.xml
+++ b/portal-web/docroot/WEB-INF/web.xml
@@ -766,10 +766,10 @@
 		<url-pattern>/webdav/*</url-pattern>
 	</servlet-mapping>
 	<session-config>
-		<session-timeout>30</session-timeout>
 		<cookie-config>
 			<http-only>true</http-only>
 		</cookie-config>
+		<session-timeout>30</session-timeout>
 	</session-config>
 	<mime-mapping>
 		<extension>js</extension>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-61285

Hi Tomáš,

If you have any concerns, check our conversation at lipusz#103 starting from https://github.com/lipusz/liferay-portal/pull/103#issuecomment-170864098

Cheers,
Tibor

/cc @jorgediaz-lr