### PR TITLE
LPS-62144 Redirect after FastPortlet successful login ActionRequest

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/LoginMVCActionCommand.java
@@ -26,6 +26,7 @@ import com.liferay.portal.UserPasswordException;
 import com.liferay.portal.UserScreenNameException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.session.AuthenticatedSessionManagerUtil;
@@ -99,8 +100,14 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 				actionRequest, "doActionAfterLogin");
 
 			if (doActionAfterLogin) {
-				actionResponse.setRenderParameter(
-					"mvcPath", "/login_redirect.jsp");
+				PortletURL renderURL =
+					((LiferayPortletResponse)actionResponse).createRenderURL();
+
+				renderURL.setParameter(
+					"mvcRenderCommandName", "/login/login_redirect");
+
+				actionRequest.setAttribute(
+					WebKeys.REDIRECT, renderURL.toString());
 			}
 		}
 		catch (Exception e) {


### PR DESCRIPTION
Hi Tomas. As discussed, we need to issue a redirect after a successful login request which has no redirect parameter, because p_p_auth gets invalidated. I originally implemented this into SecurityPortletContainerWrapper, but then discovered there was already code in LoginMVCActionCommand specifically for handling successful logins by FastLoginPortlet. So I re-wrote to provide a more targeted fix with less overall portal impact. Happy to change it if you prefer the original approach. Thanks!