### PR TITLE
LPS-62699 Login related attributes must always be set into the HttpSe…

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
@@ -153,6 +153,8 @@ public class AuthenticatedSessionManagerImpl
 			String login, String password, boolean rememberMe, String authType)
 		throws Exception {
 
+		request = PortalUtil.getOriginalServletRequest(request);
+
 		CookieKeys.validateSupportCookie(request);
 
 		HttpSession session = request.getSession();


### PR DESCRIPTION
…ssion without any attribute prefix

I think this change should not be necessary because AuthenticatedSessionManagerImpl.login(HttpServletRequest, ...) should **not** provided with a HttpServletRequest subclass (HttpServletRequestBuilderWrapperImpl) instance which applies prefixes depending on which module is calling the method via AuthenticatedSessionManagerUtil.

However, this change would not regress if the underlying platform issue is agreed/resolved so I suggest we go ahead with it.