### PR TITLE
LPS-62949 User with permissions for Site Admin menu can access message boards

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/resource-actions/default.xml
@@ -14,7 +14,6 @@
 				<action-key>VIEW</action-key>
 			</site-member-defaults>
 			<guest-defaults>
-				<action-key>ACCESS_IN_CONTROL_PANEL</action-key>
 				<action-key>VIEW</action-key>
 			</guest-defaults>
 			<guest-unsupported>


### PR DESCRIPTION
I've removed the root cause that you identified and done smokescreen testing to ensure this doesn't affect a user with only limited message board permissions from carrying out activities: posting threads, replying to threads, subscribing and viewing subscriptions.