### PR TITLE
[TS] LPS-66688 Password reset link points to blank page if it's invoked by a user having an active session

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
+++ b/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
@@ -762,6 +762,8 @@ public class PortalRequestProcessor extends TilesRequestProcessor {
 			else if ((user != null) && !user.isPasswordReset() &&
 					 path.equals(_PATH_PORTAL_UPDATE_PASSWORD)) {
 
+				response.sendRedirect(themeDisplay.getPathMain());
+
 				return null;
 			}
 


### PR DESCRIPTION
[LPS-66688](https://issues.liferay.com/browse/LPS-66688)

Hi Tomáš,

See István's comment:

>**redirect to the main path just as in the case of calling /c/portal/login with logged in user.** (At the end, user will end up on the last visited page due to the logic in PortalRequestProcessor.process(HttpServletRequest, HttpServletResponse).)

First, I was hesitating to accept his solution - because sending redirect form "processPath" didn't seem a good choice based on Struts: http://grepcode.com/file/repo1.maven.org/maven2/org.apache.struts/struts-core/1.3.10/org/apache/struts/action/RequestProcessor.java#RequestProcessor.processPath%28javax.servlet.http.HttpServletRequest%2Cjavax.servlet.http.HttpServletResponse%29

>Identify and return the path component (from the request URI) that we will use to select an ActionMapping with which to dispatch. If no such path can be identified, create an error response and return null.

Btw, the related code block which returns "null" was added to our code to fix https://issues.liferay.com/browse/LPS-27752.

In the end, I couldn't find a better approach so I'm forwarding to you.

Thank you for reviewing.

Regards,
Tibor

----
Author: @istvansajtos
Reviewers: @lipusz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/topolik/liferay-portal/358)
<!-- Reviewable:end -->
