### PR TITLE
LPS-69487 Orphan PortletPreferences

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.model.Plugin;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletConstants;
+import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.model.PortletPreferencesIds;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -426,6 +427,44 @@ public class LayoutTypePortletImpl
 		List<String> columns = layoutTemplate.getColumns();
 
 		return columns.size();
+	}
+
+	@Override
+	public List<Portlet> getOrphanPortlets(boolean includeSystem) {
+		List<Portlet> explicitlyAddedPortlets = getExplicitlyAddedPortlets();
+
+		List<String> explicitlyAddedPortletIds = new ArrayList<>();
+
+		for (Portlet explicitlyAddedPortlet : explicitlyAddedPortlets) {
+			explicitlyAddedPortletIds.add(
+				explicitlyAddedPortlet.getPortletId());
+		}
+
+		List<Portlet> orphanPortlets = new ArrayList<>();
+
+		List<PortletPreferences> portletPreferences =
+			PortletPreferencesLocalServiceUtil.getPortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, getPlid());
+
+		for (PortletPreferences portletPreference : portletPreferences) {
+			String portletId = portletPreference.getPortletId();
+
+			Portlet portlet = PortletLocalServiceUtil.getPortletById(
+				getCompanyId(), portletId);
+
+			if (portlet.isSystem() && !includeSystem) {
+				continue;
+			}
+
+			if (explicitlyAddedPortletIds.contains(portletId)) {
+				continue;
+			}
+
+			orphanPortlets.add(portlet);
+		}
+
+		return orphanPortlets;
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutTypePortlet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutTypePortlet.java
@@ -104,6 +104,8 @@ public interface LayoutTypePortlet extends LayoutType {
 
 	public int getNumOfColumns();
 
+	public List<Portlet> getOrphanPortlets(boolean includeSystem);
+
 	public PortalPreferences getPortalPreferences();
 
 	public List<String> getPortletIds();

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 2.0.0


### PR DESCRIPTION
Hey @topolik,

We've created a new method to get the orphan portlet. In this method, we are getting all portlet preferences of a layout and we are checking if those preferences match with the portlets added explicitly in a page. The portlet preferences that not match with the portlet in the page are the orphan portlets.

Please let me know if you have any question.

Thanks!!!