### PR TITLE
[TS] LPS-73087 Reflected XSS in Sign In

### DIFF
--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -88,7 +88,7 @@
 									</c:if>
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= userPassword %>" key="thank-you-for-creating-an-account.-your-password-is-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= HtmlUtil.escape(userPassword) %>" key="thank-you-for-creating-an-account.-your-password-is-x" translateArguments="<%= false %>" />
 								</c:otherwise>
 							</c:choose>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73087

Hi Tomas,

I didn't escape `<liferay-ui:message arguments="<%= userEmailAddress %>"` as there is a frontend user input validation which prevents to add an email address with XSS.

/cc @ugurcancetin