### PR TITLE
LPS-74663 Range requests create high load of I/O operations in app servers temp folder

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -324,13 +324,13 @@ public class ServletResponseUtil {
 
 				response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
 
-				Range previousRange = null;
-
 				boolean sequentialRangeList = _isSequentialRangeList(ranges);
 
 				if (!sequentialRangeList) {
 					inputStream = _toRandomAccessInputStream(inputStream);
 				}
+
+				Range previousRange = null;
 
 				for (int i = 0; i < ranges.size(); i++) {
 					Range curRange = ranges.get(i);
@@ -345,18 +345,18 @@ public class ServletResponseUtil {
 							curRange.getContentRange());
 					servletOutputStream.println();
 
-					long offset = curRange.getStart();
+					long start = curRange.getStart();
 
 					if (sequentialRangeList) {
 						if (previousRange != null) {
-							offset -= previousRange.getEnd() + 1;
+							start -= previousRange.getEnd() + 1;
 						}
 
 						previousRange = curRange;
 					}
 
 					inputStream = _copyRange(
-						inputStream, servletOutputStream, offset,
+						inputStream, servletOutputStream, start,
 						curRange.getLength());
 				}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -282,7 +282,7 @@ public class ServletResponseUtil {
 					request, response, fileName, contentType, null, fullRange);
 
 				copyRange(
-					inputStream, outputStream, fullRange.getStart(),
+					fullRange.getStart(), inputStream, outputStream, true,
 					fullRange.getLength());
 			}
 			else if (ranges.size() == 1) {
@@ -300,7 +300,7 @@ public class ServletResponseUtil {
 				response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
 
 				copyRange(
-					inputStream, outputStream, range.getStart(),
+					range.getStart(), inputStream, outputStream, true,
 					range.getLength());
 			}
 			else if (ranges.size() > 1) {
@@ -621,6 +621,18 @@ public class ServletResponseUtil {
 		return copyRange(
 			new RandomAccessInputStream(inputStream), outputStream, start,
 			length);
+	}
+
+	protected static InputStream copyRange(
+			long offset, InputStream inputStream, OutputStream outputStream,
+			boolean cleanUp, long length)
+		throws IOException {
+
+		inputStream.skip(offset);
+		StreamUtil.transfer(
+			inputStream, outputStream, StreamUtil.BUFFER_SIZE, cleanUp, length);
+
+		return inputStream;
 	}
 
 	protected static void setContentLength(

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -329,6 +329,10 @@ public class ServletResponseUtil {
 				final boolean rangesSortedAndNotOverlapped =
 					rangesSortedAndNotOverlapped(ranges);
 
+				if (!rangesSortedAndNotOverlapped) {
+					inputStream = _toRandomAccessInputStream(inputStream);
+				}
+
 				for (int i = 0; i < ranges.size(); i++) {
 					Range curRange = ranges.get(i);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -281,8 +281,8 @@ public class ServletResponseUtil {
 				setHeaders(
 					request, response, fileName, contentType, null, fullRange);
 
-				copyRange(
-					fullRange.getStart(), inputStream, outputStream, true,
+				_copyRange(
+					inputStream, outputStream, fullRange.getStart(),
 					fullRange.getLength());
 			}
 			else if (ranges.size() == 1) {
@@ -299,8 +299,8 @@ public class ServletResponseUtil {
 
 				response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
 
-				copyRange(
-					range.getStart(), inputStream, outputStream, true,
+				_copyRange(
+					inputStream, outputStream, range.getStart(),
 					range.getLength());
 			}
 			else if (ranges.size() > 1) {
@@ -346,26 +346,19 @@ public class ServletResponseUtil {
 							curRange.getContentRange());
 					servletOutputStream.println();
 
-					if (rangesSortedAndNotOverlapped) {
-						long offset = curRange.getStart();
+					long offset = curRange.getStart();
 
+					if (rangesSortedAndNotOverlapped) {
 						if (previousRange != null) {
-							offset =
-								curRange.getStart() -
-									previousRange.getEnd() - 1;
+							offset -= previousRange.getEnd() + 1;
 						}
 
 						previousRange = curRange;
+					}
 
-						inputStream = copyRange(
-							offset, inputStream, servletOutputStream, false,
-							curRange.getLength());
-					}
-					else {
-						inputStream = _copyRange(
-							inputStream, servletOutputStream,
-							curRange.getStart(), curRange.getLength());
-					}
+					inputStream = _copyRange(
+						inputStream, servletOutputStream, offset,
+						curRange.getLength());
 				}
 
 				servletOutputStream.println();
@@ -618,18 +611,6 @@ public class ServletResponseUtil {
 			length);
 	}
 
-	protected static InputStream copyRange(
-			long offset, InputStream inputStream, OutputStream outputStream,
-			boolean cleanUp, long length)
-		throws IOException {
-
-		inputStream.skip(offset);
-		StreamUtil.transfer(
-			inputStream, outputStream, StreamUtil.BUFFER_SIZE, cleanUp, length);
-
-		return inputStream;
-	}
-
 	protected static boolean rangesSortedAndNotOverlapped(List<Range> ranges) {
 		Range previousRange = null;
 
@@ -807,8 +788,12 @@ public class ServletResponseUtil {
 			return randomAccessInputStream;
 		}
 
-		throw new IllegalArgumentException(
-			"InputStream must support random access");
+		inputStream.skip(start);
+
+		StreamUtil.transfer(
+			inputStream, outputStream, StreamUtil.BUFFER_SIZE, false, length);
+
+		return inputStream;
 	}
 
 	private static InputStream _toRandomAccessInputStream(

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -328,9 +328,7 @@ public class ServletResponseUtil {
 
 				Range previousRange = null;
 
-				for (int i = 0; i < ranges.size(); i++) {
-					Range curRange = ranges.get(i);
-
+				for (Range curRange : ranges) {
 					servletOutputStream.println();
 					servletOutputStream.println(
 						StringPool.DOUBLE_DASH + boundary);

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -324,8 +324,13 @@ public class ServletResponseUtil {
 
 				response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
 
+				Range previousRange = null;
+
+				final boolean rangesSortedAndNotOverlapped =
+					rangesSortedAndNotOverlapped(ranges);
+
 				for (int i = 0; i < ranges.size(); i++) {
-					Range range = ranges.get(i);
+					Range curRange = ranges.get(i);
 
 					servletOutputStream.println();
 					servletOutputStream.println(
@@ -334,12 +339,29 @@ public class ServletResponseUtil {
 						HttpHeaders.CONTENT_TYPE + ": " + contentType);
 					servletOutputStream.println(
 						HttpHeaders.CONTENT_RANGE + ": " +
-							range.getContentRange());
+							curRange.getContentRange());
 					servletOutputStream.println();
 
-					inputStream = copyRange(
-						inputStream, outputStream, range.getStart(),
-						range.getLength());
+					if (rangesSortedAndNotOverlapped) {
+						long offset = curRange.getStart();
+
+						if (previousRange != null) {
+							offset =
+								curRange.getStart() -
+									previousRange.getEnd() - 1;
+						}
+
+						previousRange = curRange;
+
+						inputStream = copyRange(
+							offset, inputStream, servletOutputStream, false,
+							curRange.getLength());
+					}
+					else {
+						inputStream = copyRange(
+							inputStream, servletOutputStream,
+							curRange.getStart(), curRange.getLength());
+					}
 				}
 
 				servletOutputStream.println();
@@ -633,6 +655,22 @@ public class ServletResponseUtil {
 			inputStream, outputStream, StreamUtil.BUFFER_SIZE, cleanUp, length);
 
 		return inputStream;
+	}
+
+	protected static boolean rangesSortedAndNotOverlapped(List<Range> ranges) {
+		Range previousRange = null;
+
+		for (Range range : ranges) {
+			if ((previousRange != null) &&
+				(range.getStart() <= previousRange.getEnd())) {
+
+				return false;
+			}
+
+			previousRange = range;
+		}
+
+		return true;
 	}
 
 	protected static void setContentLength(

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -358,7 +358,7 @@ public class ServletResponseUtil {
 							curRange.getLength());
 					}
 					else {
-						inputStream = copyRange(
+						inputStream = _copyRange(
 							inputStream, servletOutputStream,
 							curRange.getStart(), curRange.getLength());
 					}
@@ -600,48 +600,17 @@ public class ServletResponseUtil {
 		}
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	protected static InputStream copyRange(
 			InputStream inputStream, OutputStream outputStream, long start,
 			long length)
 		throws IOException {
 
-		if (inputStream instanceof FileInputStream) {
-			FileInputStream fileInputStream = (FileInputStream)inputStream;
-
-			FileChannel fileChannel = fileInputStream.getChannel();
-
-			fileChannel.transferTo(
-				start, length, Channels.newChannel(outputStream));
-
-			return fileInputStream;
-		}
-		else if (inputStream instanceof ByteArrayInputStream) {
-			ByteArrayInputStream byteArrayInputStream =
-				(ByteArrayInputStream)inputStream;
-
-			byteArrayInputStream.reset();
-
-			byteArrayInputStream.skip(start);
-
-			StreamUtil.transfer(byteArrayInputStream, outputStream, length);
-
-			return byteArrayInputStream;
-		}
-		else if (inputStream instanceof RandomAccessInputStream) {
-			RandomAccessInputStream randomAccessInputStream =
-				(RandomAccessInputStream)inputStream;
-
-			randomAccessInputStream.seek(start);
-
-			StreamUtil.transfer(
-				randomAccessInputStream, outputStream, StreamUtil.BUFFER_SIZE,
-				false, length);
-
-			return randomAccessInputStream;
-		}
-
-		return copyRange(
-			new RandomAccessInputStream(inputStream), outputStream, start,
+		return _copyRange(
+			_toRandomAccessInputStream(inputStream), outputStream, start,
 			length);
 	}
 
@@ -792,6 +761,64 @@ public class ServletResponseUtil {
 			response.setHeader(
 				HttpHeaders.CONTENT_LENGTH, String.valueOf(range.getLength()));
 		}
+	}
+
+	private static InputStream _copyRange(
+			InputStream inputStream, OutputStream outputStream, long start,
+			long length)
+		throws IOException {
+
+		if (inputStream instanceof FileInputStream) {
+			FileInputStream fileInputStream = (FileInputStream)inputStream;
+
+			FileChannel fileChannel = fileInputStream.getChannel();
+
+			fileChannel.transferTo(
+				start, length, Channels.newChannel(outputStream));
+
+			return fileInputStream;
+		}
+		else if (inputStream instanceof ByteArrayInputStream) {
+			ByteArrayInputStream byteArrayInputStream =
+				(ByteArrayInputStream)inputStream;
+
+			byteArrayInputStream.reset();
+
+			byteArrayInputStream.skip(start);
+
+			StreamUtil.transfer(byteArrayInputStream, outputStream, length);
+
+			return byteArrayInputStream;
+		}
+		else if (inputStream instanceof RandomAccessInputStream) {
+			RandomAccessInputStream randomAccessInputStream =
+				(RandomAccessInputStream)inputStream;
+
+			randomAccessInputStream.seek(start);
+
+			StreamUtil.transfer(
+				randomAccessInputStream, outputStream, StreamUtil.BUFFER_SIZE,
+				false, length);
+
+			return randomAccessInputStream;
+		}
+
+		throw new IllegalArgumentException(
+			"InputStream must support random access");
+	}
+
+	private static InputStream _toRandomAccessInputStream(
+			InputStream inputStream)
+		throws IOException {
+
+		if (inputStream instanceof ByteArrayInputStream ||
+			inputStream instanceof FileInputStream ||
+			inputStream instanceof RandomAccessInputStream) {
+
+			return inputStream;
+		}
+
+		return new RandomAccessInputStream(inputStream);
 	}
 
 	private static final String _CLIENT_ABORT_EXCEPTION =

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -355,7 +355,7 @@ public class ServletResponseUtil {
 						previousRange = curRange;
 					}
 
-					inputStream = _copyRange(
+					_copyRange(
 						inputStream, servletOutputStream, start,
 						curRange.getLength());
 				}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -258,11 +258,7 @@ public class ServletResponseUtil {
 			long fullLength, String contentType)
 		throws IOException {
 
-		OutputStream outputStream = null;
-
-		try {
-			outputStream = response.getOutputStream();
-
+		try (OutputStream outputStream = response.getOutputStream()) {
 			Range fullRange = new Range(0, fullLength - 1, fullLength);
 
 			Range firstRange = null;
@@ -366,11 +362,7 @@ public class ServletResponseUtil {
 			}
 		}
 		finally {
-			try {
-				inputStream.close();
-			}
-			catch (IOException ioe) {
-			}
+			StreamUtil.cleanUp(inputStream);
 		}
 	}
 
@@ -770,7 +762,9 @@ public class ServletResponseUtil {
 
 			byteArrayInputStream.skip(start);
 
-			StreamUtil.transfer(byteArrayInputStream, outputStream, length);
+			StreamUtil.transfer(
+				byteArrayInputStream, outputStream, StreamUtil.BUFFER_SIZE,
+				false, length);
 
 			return byteArrayInputStream;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -326,10 +326,9 @@ public class ServletResponseUtil {
 
 				Range previousRange = null;
 
-				final boolean rangesSortedAndNotOverlapped =
-					rangesSortedAndNotOverlapped(ranges);
+				boolean sequentialRangeList = _isSequentialRangeList(ranges);
 
-				if (!rangesSortedAndNotOverlapped) {
+				if (!sequentialRangeList) {
 					inputStream = _toRandomAccessInputStream(inputStream);
 				}
 
@@ -348,7 +347,7 @@ public class ServletResponseUtil {
 
 					long offset = curRange.getStart();
 
-					if (rangesSortedAndNotOverlapped) {
+					if (sequentialRangeList) {
 						if (previousRange != null) {
 							offset -= previousRange.getEnd() + 1;
 						}
@@ -611,7 +610,7 @@ public class ServletResponseUtil {
 			length);
 	}
 
-	protected static boolean rangesSortedAndNotOverlapped(List<Range> ranges) {
+	private static boolean _isSequentialRangeList(List<Range> ranges) {
 		Range previousRange = null;
 
 		for (Range range : ranges) {

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -600,22 +600,6 @@ public class ServletResponseUtil {
 			length);
 	}
 
-	private static boolean _isSequentialRangeList(List<Range> ranges) {
-		Range previousRange = null;
-
-		for (Range range : ranges) {
-			if ((previousRange != null) &&
-				(range.getStart() <= previousRange.getEnd())) {
-
-				return false;
-			}
-
-			previousRange = range;
-		}
-
-		return true;
-	}
-
 	protected static void setContentLength(
 		HttpServletResponse response, long contentLength) {
 
@@ -787,14 +771,38 @@ public class ServletResponseUtil {
 		return inputStream;
 	}
 
-	private static InputStream _toRandomAccessInputStream(
-			InputStream inputStream)
-		throws IOException {
-
+	private static boolean _isRandomAccessSupported(InputStream inputStream) {
 		if (inputStream instanceof ByteArrayInputStream ||
 			inputStream instanceof FileInputStream ||
 			inputStream instanceof RandomAccessInputStream) {
 
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isSequentialRangeList(List<Range> ranges) {
+		Range previousRange = null;
+
+		for (Range range : ranges) {
+			if ((previousRange != null) &&
+				(range.getStart() <= previousRange.getEnd())) {
+
+				return false;
+			}
+
+			previousRange = range;
+		}
+
+		return true;
+	}
+
+	private static InputStream _toRandomAccessInputStream(
+			InputStream inputStream)
+		throws IOException {
+
+		if (_isRandomAccessSupported(inputStream)) {
 			return inputStream;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-74663
Hi @topolik ,
The main issue is explained in the LPS description but just to give some context:
To serve every request with a range header a temporary file is being created. In ServletResponseUtil.copyRange method a RandomAccessInputStream is being instanced which uses this file as an internal cache.

As random access is not needed to satisfy some requests, we've tried to avoid using it in the use cases that could be satisfied with sequential reading (see PTR-169). The use cases we've considered are the following:

- If single range is requested: we will serve it without creating a temp file.
- If non overlapping and ordered ranges are requested: we will serve them without creating a temp file.
- If overlapping and/or unordered ranges are requested: we will keep the current logic to support them (temp file will be created).

Thanks!

