### PR TITLE
LPS-76323

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
@@ -117,13 +117,17 @@ public class AntiSamySanitizerImpl extends BaseSanitizer {
 		String classNameAndClassPK = className + StringPool.POUND + classPK;
 
 		for (String blacklistItem : _blacklist) {
-			if (classNameAndClassPK.startsWith(blacklistItem)) {
+			if (blacklistItem.equals(StringPool.STAR) ||
+				classNameAndClassPK.startsWith(blacklistItem)) {
+
 				return false;
 			}
 		}
 
 		for (String whitelistItem : _whitelist) {
-			if (classNameAndClassPK.startsWith(whitelistItem)) {
+			if (whitelistItem.equals(StringPool.STAR) ||
+				classNameAndClassPK.startsWith(whitelistItem)) {
+
 				return true;
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/usecase/DocumentsadministrationUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/usecase/DocumentsadministrationUsecase.testcase
@@ -1857,7 +1857,7 @@
 	</command>
 
 	<command name="ViewFileCategoryAndTags" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 		<property name="testray.component.names" value="Training" />
 
 		<execute macro="ProductMenu#gotoPortlet">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -21,7 +21,8 @@
 	</tear-down>
 
 	<command name="RightToLeftSmoke" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
+		<property name="test.name.skip.portal.instance" value="UIInfrastructureUsecase#RightToLeftSmoke" />
 
 		<execute macro="ProductMenu#gotoPortlet">
 			<var name="category" value="Navigation" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/categories/cpcategories/CPCategories.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/categories/cpcategories/CPCategories.testcase
@@ -1252,7 +1252,7 @@
 	</command>
 
 	<command name="EditCategory" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<execute macro="Navigator#openURL" />
 
@@ -1364,7 +1364,7 @@
 	</command>
 
 	<command name="EditSubcategory" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 		<property name="testray.component.names" value="Training" />
 
 		<execute macro="Navigator#openURL" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/contentandapplicationtemplates/usecase/ApplicationdisplaytemplatesUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/contentandapplicationtemplates/usecase/ApplicationdisplaytemplatesUsecase.testcase
@@ -332,7 +332,7 @@
 	</command>
 
 	<command name="ADTCategoriesNavigation" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 		<property name="testray.component.names" value="Categories,Content and Application Templates" />
 
 		<execute macro="ProductMenu#gotoSite">


### PR DESCRIPTION
@topolik,

Currently, '*' is not handled by Antisamy so you cannot use this as a wildcard and must enumerate all of the options. This fix allows that to work properly.

Additionally, the documentation for setting the black and white list is incorrect (https://dev.liferay.com/discover/deployment/-/knowledge_base/7-0/antisamy). It says to use ```com.liferay.message.boards.*```, but in the code we're checking for ```startsWith```. Anything with the trailing ```.*``` will never be matched, so the documentation should be updated to read ```com.liferay.message.boards``` instead.

Please let me know if you have any questions or concern.