### PR TITLE
[TECHNICAL-SUPPORT] LPS-76666

### DIFF
--- a/modules/apps/foundation/petra/petra-json-web-service-client/build.gradle
+++ b/modules/apps/foundation/petra/petra-json-web-service-client/build.gradle
@@ -2,9 +2,9 @@ sourceCompatibility = "1.6"
 targetCompatibility = "1.6"
 
 dependencies {
-	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.4.2"
-	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.4.2"
-	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.4.2"
+	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.6.7"
+	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.6.7"
+	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.6.7.1"
 	compileInclude group: "commons-codec", name: "commons-codec", version: "1.7"
 	compileInclude group: "org.apache.httpcomponents", name: "httpasyncclient", version: "4.1.3"
 	compileInclude group: "org.apache.httpcomponents", name: "httpclient", version: "4.5.3"


### PR DESCRIPTION
@topolik Version 2.6.7.1 was the minimum version increase I could do in order to reach a patched version of the library. If you want to simply move to the latest, that would be 2.9.3.

Also, here is the test that I used to confirm that our current implementation is vulnerable:

https://github.com/jonathanmccann/liferay-portal/commit/bd126ee7cb45016d837eec7514aae9769a46138d

I didn't include this test because it's only testing the ObjectMapper and not calling our actual client. If you'd like to include it, let me know.

Please let me know if you have any questions or concerns.