### PR TITLE
LPS-66243

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -517,7 +517,7 @@
     # Set a list of comma delimited portlet IDs that will bypass the security
     # check set in the property "portlet.add.default.resource.check.enabled".
     #
-    portlet.add.default.resource.check.whitelist=com_liferay_calendar_web_portlet_CalendarPortlet,com_liferay_login_web_portlet_LoginPortlet,com_liferay_portlet_configuration_web_portlet_PortletConfigurationPortlet,com_liferay_portlet_configuration_css_web_portlet_PortletConfigurationCSSPortlet,145,164,166,com_liferay_product_navigation_simulation_web_portlet_SimulationPortlet,com_liferay_staging_bar_web_portlet_StagingBarPortlet
+    portlet.add.default.resource.check.whitelist=com_liferay_calendar_web_portlet_CalendarPortlet,com_liferay_dynamic_data_mapping_web_portlet_DDMPortlet,com_liferay_login_web_portlet_FastLoginPortlet,com_liferay_login_web_portlet_LoginPortlet,com_liferay_portlet_configuration_web_portlet_PortletConfigurationPortlet,com_liferay_portlet_configuration_css_web_portlet_PortletConfigurationCSSPortlet,com_liferay_product_navigation_simulation_web_portlet_SimulationPortlet,com_liferay_staging_bar_web_portlet_StagingBarPortlet
 
     #
     # Input a list of comma delimited struts actions that will bypass the


### PR DESCRIPTION
im not sure how, or if, this portal property is used, but i think the default value should be updated for these three portlet ids?

145 -> was removed in https://issues.liferay.com/browse/LPS-65297

164 -> https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/internal/upgrade/v1_0_0/UpgradePortletId.java#L29

166-> https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/upgrade/v1_0_0/UpgradePortletId.java#L28