### PR TITLE
LPS-78528 Limit Web Proxy to administrators

### DIFF
--- a/modules/apps/foundation/web-proxy/web-proxy-web/src/main/java/com/liferay/web/proxy/web/internal/portlet/WebProxyPortlet.java
+++ b/modules/apps/foundation/web-proxy/web-proxy-web/src/main/java/com/liferay/web/proxy/web/internal/portlet/WebProxyPortlet.java
@@ -83,7 +83,7 @@ import org.portletbridge.portlet.PortletBridgeServlet;
 		"javax.portlet.name=" + WebProxyPortletKeys.WEB_PROXY,
 		"javax.portlet.preferences=classpath:/META-INF/portlet-preferences/default-portlet-preferences.xml",
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=power-user,user"
+		"javax.portlet.security-role-ref=administrator"
 	},
 	service = Portlet.class
 )


### PR DESCRIPTION
It seems like all the issues (LPS-50325, LPS-51026, LPS-49451) we had in the past with the XSL Content portlet also applies to the Web Proxy portlet. So I'm taking the same approach that we used for XSL Content portlet and limit the Web Proxy portlet to administrators.