### PR TITLE
LPS-66371

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3184,22 +3184,16 @@
     auth.token.ignore.actions=\
         /asset/rss,\
         \
-        /blogs/edit_entry,\
         /blogs/rss,\
         /blogs/trackback,\
         \
-        /blogs_aggregator/edit_entry,\
         /blogs_aggregator/rss,\
-        \
-        /document_library/edit_file_entry,\
         \
         /login/create_account,\
         /login/login,\
         \
-        /message_boards/edit_message,\
         /message_boards/rss,\
         \
-        /portal/comment/edit_discussion,\
         /portal/comment/get_comments
 
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3195,7 +3195,6 @@
         /message_boards/rss,\
         \
         /portal/comment/get_comments
-
     #auth.token.ignore.actions=\
     #    /asset/rss,\
     #    \

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3196,6 +3196,27 @@
         \
         /portal/comment/get_comments
 
+    #auth.token.ignore.actions=\
+    #    /asset/rss,\
+    #    \
+    #    /blogs/edit_entry,\
+    #    /blogs/rss,\
+    #    /blogs/trackback,\
+    #    \
+    #    /blogs_aggregator/edit_entry,\
+    #    /blogs_aggregator/rss,\
+    #    \
+    #    /document_library/edit_file_entry,\
+    #    \
+    #    /login/create_account,\
+    #    /login/login,\
+    #    \
+    #    /message_boards/edit_message,\
+    #    /message_boards/rss,\
+    #    \
+    #    /portal/comment/edit_discussion,\
+    #    /portal/comment/get_comments
+
     #
     # Set a list of comma delimited origins that will not be checked for an
     # authentication token.


### PR DESCRIPTION
This change will
* Prevent blog & MB drafts from saving if the user's session expires
* Prevent guest users from commenting

The portal should be secure by default, so admins that want these features should make the necessary changes.

`/document_library/edit_file_entry` this was originally for the flash uploader, which I don't think we use any more.
