### PR TITLE
[TECHNICAL SUPPORT] LPS-79425

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1717,7 +1717,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 	};
 
 	private static final String[] _ESCAPED_CHARS = {
-		"\\\\\\\\\\\\", "\\\\\"", "\\\\,", "\\\\#", "\\\\+", "\\\\<", "\\\\>",
+		"\\\\\\\\", "\\\\\"", "\\\\,", "\\\\#", "\\\\+", "\\\\<", "\\\\>",
 		"\\\\;", "\\\\=", "\\\\ "
 	};
 
@@ -1726,7 +1726,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 	private static final String _IMPORT_BY_USER = "user";
 
 	private static final String[] _UNESCAPED_CHARS = {
-		"\\\\\\", "\\\"", "\\,", "\\#", "\\+", "\\<", "\\>", "\\;", "\\=", "\\ "
+		"\\\\", "\\\"", "\\,", "\\#", "\\+", "\\<", "\\>", "\\;", "\\=", "\\ "
 	};
 
 	private static final String _USER_PASSWORD_SCREEN_NAME = "screenName";

--- a/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -94,6 +94,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import javax.naming.Binding;
+import javax.naming.InvalidNameException;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.Attribute;
@@ -101,6 +102,8 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
 
 import org.apache.commons.lang.time.StopWatch;
 
@@ -651,6 +654,16 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 		}
 	}
 
+	protected String cleanupLdapName(String name) throws InvalidNameException {
+		LdapName ldapNameString = new LdapName(name);
+
+		List<Rdn> rdns = ldapNameString.getRdns();
+
+		LdapName ldapNameRdns = new LdapName(rdns);
+
+		return ldapNameRdns.toString();
+	}
+
 	protected String escapeValue(String value) {
 		return StringUtil.replace(value, _UNESCAPED_CHARS, _ESCAPED_CHARS);
 	}
@@ -981,6 +994,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 				user.getEmailAddress());
 
 			String fullUserDN = binding.getNameInNamespace();
+
+			fullUserDN = cleanupLdapName(fullUserDN);
 
 			sb.append(escapeValue(fullUserDN));
 
@@ -1702,15 +1717,17 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 	};
 
 	private static final String[] _ESCAPED_CHARS = {
-		"\\\\,", "\\\\#", "\\\\+", "\\\\<", "\\\\>", "\\\\;", "\\\\=", "\\\\ "
+		"\\\\\\\\\\\\", "\\\\\"", "\\\\,", "\\\\#", "\\\\+", "\\\\<", "\\\\>",
+		"\\\\;", "\\\\=", "\\\\ "
 	};
 
 	private static final String _IMPORT_BY_GROUP = "group";
 
 	private static final String _IMPORT_BY_USER = "user";
 
-	private static final String[] _UNESCAPED_CHARS =
-		{"\\,", "\\#", "\\+", "\\<", "\\>", "\\;", "\\=", "\\ "};
+	private static final String[] _UNESCAPED_CHARS = {
+		"\\\\\\", "\\\"", "\\,", "\\#", "\\+", "\\<", "\\>", "\\;", "\\=", "\\ "
+	};
 
 	private static final String _USER_PASSWORD_SCREEN_NAME = "screenName";
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79425 

The user full DN from LDAP is returned by binding.getNameInNamespace() and we use it to query the assigned groups in LDAP.
In case of having a user full DN with special characters encoding in hex way (ex '\2c' instead of '\,') we are having problems in the LDAP query.

Using javax.naming.ldap.LdapName we can force all encoded special characters to be rewritten to the simple mode: \xx to \c and we avoid all query issues.

This hex encoding is only reproduced in case of using OpenLDAP, but if you review LDAP RFC both escape options are correct.

For more information, see LPS description and LDAP RFC https://docs.ldap.com/specs/rfc4514.txt