### PR TITLE
[TS] LPS-79480 doAsUserId param added to the external URLs when page type is link to URL

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3225,9 +3225,6 @@ public class PortalImpl implements Portal {
 
 		String layoutURL = getLayoutActualURL(layout);
 
-		layoutURL = addPreservedParameters(
-			themeDisplay, layout, layoutURL, doAsUser);
-
 		return layoutURL;
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3223,9 +3223,7 @@ public class PortalImpl implements Portal {
 			}
 		}
 
-		String layoutURL = getLayoutActualURL(layout);
-
-		return layoutURL;
+		return getLayoutActualURL(layout);
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79480

Hi Tomas,

There is no point to add any preserved parametes to external URLs so I agree with Roland's change. The other layout types are handled above this code block in the if-clause.

Regards,
Tibor

Author: @rolandpakai
Reviewers: @lipusz