### PR TITLE
[TS] LPS-82035 Referer parameter is vulnerable against javascript: protocol

### DIFF
--- a/portal-web/docroot/html/common/referer_js.jsp
+++ b/portal-web/docroot/html/common/referer_js.jsp
@@ -36,5 +36,10 @@ pageContext.setAttribute(WebKeys.THEME_DEFINE_OBJECTS, Boolean.FALSE);
 		document.execCommand('ClearAuthenticationCache');
 	</c:if>
 
-	location.href = '<%= HtmlUtil.escapeJS(referer) %>';
+	<%
+	referer = HtmlUtil.escapeJSLink(referer);
+	referer = HtmlUtil.escapeJS(referer);
+	%>
+
+	location.href = '<%= referer %>';
 </script>


### PR DESCRIPTION
[LPS-82035](https://issues.liferay.com/browse/LPS-82035)

Hi Tomas,

I'm sending this directly to you as Tibor Lipusz doesn't have time to review it.

**Issue:** the referer parameter is vulnerable against javascript protocol. I could trigger it only with very specifically built-up values of referer parameter. Please see the details of reproduction on the LPS.

[LPS-42787](https://issues.liferay.com/browse/LPS-42787) solved a similar issue, but it is for HREF attribute. As I see, escapeJSLink(String) method is the only thing I need here. 

Please let me know if you have any concerns.

Thank you in advance,
Istvan