### PR TITLE
OAUTH2-150 Fix for guest.allowed

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest-spi/src/main/java/com/liferay/oauth2/provider/rest/spi/scope/checker/container/request/filter/BaseScopeCheckerContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest-spi/src/main/java/com/liferay/oauth2/provider/rest/spi/scope/checker/container/request/filter/BaseScopeCheckerContainerRequestFilter.java
@@ -70,9 +70,11 @@ public abstract class BaseScopeCheckerContainerRequestFilter
 
 				return false;
 			}
+
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 }


### PR DESCRIPTION
/cc @martamedio

guys... can you review this and push to Brian? it is breaking `guest.allowed` support

for instance an application with:
```
auth.verifier.auth.verifier.BasicAuthHeaderAuthVerifier.urls.includes="*"
auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes="*"
auth.verifier.guest.allowed="true"
```