### PR TITLE
OAUTH2-159 Do not auto-assign implied scope aliases to applications

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
@@ -73,8 +73,6 @@ if (oAuth2Application.getOAuth2ApplicationScopeAliasesId() > 0) {
 						<aui:button href="<%= PortalUtil.escapeRedirect(redirect) %>" type="cancel" />
 					</aui:button-row>
 				</div>
-
-				<aui:input id="impliedScopeAliases" name="scopeAliases" type="hidden" />
 			</aui:form>
 		</div>
 	</div>
@@ -229,20 +227,5 @@ if (oAuth2Application.getOAuth2ApplicationScopeAliasesId() > 0) {
 	%>
 
 	<portlet:namespace />recalculateAll();
-
-	A.one('#<portlet:namespace />save').on(
-		'click',
-		function(event) {
-			event.preventDefault();
-
-			var scopeAliases = [];
-			A.all('input[name="<portlet:namespace />scopeAliases"]:checked:disabled').each(
-				function() {
-					scopeAliases.push(this.val());
-				});
-			A.one('#<portlet:namespace />impliedScopeAliases').attr('value', scopeAliases.join(','));
-
-			document.<portlet:namespace/>fm.submit();
-		});
 
 </aui:script>


### PR DESCRIPTION
Following our conversation about "contracts" between OAuth2 admin and portal admin