### PR TITLE
OAUTH2-214 Some further issues fixed

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
@@ -236,6 +236,10 @@ public interface OAuth2ApplicationScopeAliasesLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasUpToDateScopeGrants(
+		OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases);
+
 	/**
 	* Updates the o auth2 application scope aliases in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	*

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
@@ -271,6 +271,11 @@ public class OAuth2ApplicationScopeAliasesLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static boolean hasUpToDateScopeGrants(
+		com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases) {
+		return getService().hasUpToDateScopeGrants(oAuth2ApplicationScopeAliases);
+	}
+
 	/**
 	* Updates the o auth2 application scope aliases in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	*

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
@@ -279,6 +279,12 @@ public class OAuth2ApplicationScopeAliasesLocalServiceWrapper
 		return _oAuth2ApplicationScopeAliasesLocalService.getPersistedModel(primaryKeyObj);
 	}
 
+	@Override
+	public boolean hasUpToDateScopeGrants(
+		com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases) {
+		return _oAuth2ApplicationScopeAliasesLocalService.hasUpToDateScopeGrants(oAuth2ApplicationScopeAliases);
+	}
+
 	/**
 	* Updates the o auth2 application scope aliases in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	*

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -357,44 +357,17 @@ public class OAuth2ApplicationLocalServiceImpl
 			return oAuth2ApplicationPersistence.update(oAuth2Application);
 		}
 
-		if (oAuth2Application.getOAuth2ApplicationScopeAliasesId() == 0) {
-			OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
-				oAuth2ApplicationScopeAliasesLocalService.
-					fetchOAuth2ApplicationScopeAliases(
-						oAuth2ApplicationId, scopeAliasesList);
-
-			if (oAuth2ApplicationScopeAliases == null) {
-				oAuth2ApplicationScopeAliases =
-					oAuth2ApplicationScopeAliasesLocalService.
-						addOAuth2ApplicationScopeAliases(
-							oAuth2Application.getCompanyId(), userId, userName,
-							oAuth2ApplicationId, scopeAliasesList);
-			}
-
-			oAuth2Application.setModifiedDate(new Date());
-			oAuth2Application.setOAuth2ApplicationScopeAliasesId(
-				oAuth2ApplicationScopeAliases.
-					getOAuth2ApplicationScopeAliasesId());
-
-			return oAuth2ApplicationPersistence.update(oAuth2Application);
-		}
-
 		OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
-			oAuth2ApplicationScopeAliasesLocalService.
-				getOAuth2ApplicationScopeAliases(
-					oAuth2Application.getOAuth2ApplicationScopeAliasesId());
-
-		List<String> actualScopeAliasesList =
-			oAuth2ApplicationScopeAliases.getScopeAliasesList();
-
-		if (actualScopeAliasesList.equals(scopeAliasesList)) {
-			return oAuth2Application;
-		}
-
-		oAuth2ApplicationScopeAliases =
 			oAuth2ApplicationScopeAliasesLocalService.
 				fetchOAuth2ApplicationScopeAliases(
 					oAuth2ApplicationId, scopeAliasesList);
+
+		if ((oAuth2ApplicationScopeAliases != null) &&
+			!oAuth2ApplicationScopeAliasesLocalService.hasUpToDateScopeGrants(
+				oAuth2ApplicationScopeAliases)) {
+
+			oAuth2ApplicationScopeAliases = null;
+		}
 
 		if (oAuth2ApplicationScopeAliases == null) {
 			oAuth2ApplicationScopeAliases =
@@ -404,11 +377,20 @@ public class OAuth2ApplicationLocalServiceImpl
 						oAuth2ApplicationId, scopeAliasesList);
 		}
 
-		oAuth2Application.setModifiedDate(new Date());
-		oAuth2Application.setOAuth2ApplicationScopeAliasesId(
-			oAuth2ApplicationScopeAliases.getOAuth2ApplicationScopeAliasesId());
+		if (oAuth2Application.getOAuth2ApplicationScopeAliasesId() !=
+				oAuth2ApplicationScopeAliases.
+					getOAuth2ApplicationScopeAliasesId()) {
 
-		return oAuth2ApplicationPersistence.update(oAuth2Application);
+			oAuth2Application.setModifiedDate(new Date());
+			oAuth2Application.setOAuth2ApplicationScopeAliasesId(
+				oAuth2ApplicationScopeAliases.
+					getOAuth2ApplicationScopeAliasesId());
+
+			return oAuth2ApplicationPersistence.update(oAuth2Application);
+		}
+		else {
+			return oAuth2Application;
+		}
 	}
 
 	protected void validate(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -69,6 +69,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Brian Wing Shun Chan
@@ -349,6 +351,17 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		OAuth2Application oAuth2Application =
 			oAuth2ApplicationPersistence.findByPrimaryKey(oAuth2ApplicationId);
+
+		if (scopeAliasesList != null) {
+			Stream<String> stream = scopeAliasesList.stream();
+
+			scopeAliasesList = stream.filter(
+				Validator::isNotNull
+			).sorted(
+			).collect(
+				Collectors.toList()
+			);
+		}
 
 		if ((scopeAliasesList == null) || scopeAliasesList.isEmpty()) {
 			oAuth2Application.setModifiedDate(new Date());

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.osgi.framework.Bundle;
@@ -152,21 +153,26 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 			return false;
 		}
 
-		for (LiferayOAuth2Scope liferayOAuth2Scope : liferayOAuth2Scopes) {
-			String applicationName = liferayOAuth2Scope.getApplicationName();
+		for (OAuth2ScopeGrant oAuth2ScopeGrant : oAuth2ScopeGrants) {
+			boolean found = liferayOAuth2Scopes.removeIf(
+				liferayOAuth2Scope -> {
+					Bundle bundle = liferayOAuth2Scope.getBundle();
 
-			Bundle bundle = liferayOAuth2Scope.getBundle();
+					if (Objects.equals(
+							liferayOAuth2Scope.getApplicationName(),
+							oAuth2ScopeGrant.getApplicationName()) &&
+						Objects.equals(
+							bundle.getSymbolicName(),
+							oAuth2ScopeGrant.getBundleSymbolicName()) &&
+						Objects.equals(
+							liferayOAuth2Scope.getScope(),
+							oAuth2ScopeGrant.getScope())) {
 
-			String bundleSymbolicName = bundle.getSymbolicName();
+						return true;
+					}
 
-			String scope = liferayOAuth2Scope.getScope();
-
-			boolean found = oAuth2ScopeGrants.removeIf(
-				oAuth2ScopeGrant -> applicationName.equals(
-					oAuth2ScopeGrant.getApplicationName()) &&
-					bundleSymbolicName.equals(
-						oAuth2ScopeGrant.getBundleSymbolicName()) &&
-					scope.equals(oAuth2ScopeGrant.getScope()));
+					return false;
+				});
 
 			if (!found) {
 				return false;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -22,7 +22,6 @@ import com.liferay.oauth2.provider.service.base.OAuth2ApplicationScopeAliasesLoc
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.spring.extender.service.ServiceReference;
@@ -97,7 +96,7 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 		long oAuth2ApplicationId, List<String> scopeAliasesList) {
 
 		String scopeAliases = StringUtil.merge(
-			ListUtil.sort(scopeAliasesList), StringPool.SPACE);
+			scopeAliasesList, StringPool.SPACE);
 
 		List<OAuth2ApplicationScopeAliases> oAuth2ApplicationScopeAliasesList =
 			oAuth2ApplicationScopeAliasesPersistence.findByO_S(


### PR DESCRIPTION
Reviewed & squashed stian-sigvartsen/liferay-portal/pull/114 into a438574 .

Only issue I found with your changes was that Set.removeIf() was throwing UnsupportedOperationOperation because the Set provided by the caller was immutable. Fix in 
b9aeb6a

I also found that we weren't storing new ScopeAliasesLists as sorted because sorting was only done when fetching. Also we weren't stripping out empty string scope aliases passed to the updateScopeAliases by the MVCActionCommand occasionally, so we were unnecessarily creating ScopeAliases records at times.