### PR TITLE
LPS-73530 Avoid log level error, error information is already managed and printed by UI

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
@@ -662,7 +662,9 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 			super.doDispatch(renderRequest, renderResponse);
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage());
+			if (_log.isWarnEnabled()) {
+				_log.warn(e.getMessage());
+			}
 
 			SessionErrors.add(renderRequest, e.getClass());
 


### PR DESCRIPTION
Hey @topolik

From a security perspective, we launch this Exception [ActionUtil#L136](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/portletconfiguration/action/ActionUtil.java#L136) when trying to recover the Portlet and the user does not have permissions, I think this is right and we should not change it.

According to [this comment](https://issues.liferay.com/browse/LPS-73530?focusedCommentId=1474329&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1474329) I think that the only solution available for this issue to prevent the console error from being painted is this change, since no log level error is expected when is already being controlled on the UI layer.

Anyway, I'm not sure that this issue should be resolved by security team, I look forward to your comments.