### PR TITLE
LPS-86002 OpenId Connect SSO & strangers - new approach

### DIFF
--- a/modules/apps/login/login-authentication-openid-connect-web/src/main/java/com/liferay/login/authentication/openid/connect/web/internal/portlet/action/OpenIdConnectLoginRequestMVCActionCommand.java
+++ b/modules/apps/login/login-authentication-openid-connect-web/src/main/java/com/liferay/login/authentication/openid/connect/web/internal/portlet/action/OpenIdConnectLoginRequestMVCActionCommand.java
@@ -30,9 +30,12 @@ import com.liferay.portal.security.sso.openid.connect.constants.OpenIdConnectWeb
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
+import javax.portlet.MimeResponse;
+import javax.portlet.RenderURL;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -72,6 +75,22 @@ public class OpenIdConnectLoginRequestMVCActionCommand
 			HttpServletResponse httpServletResponse =
 				_portal.getHttpServletResponse(actionResponse);
 
+			HttpSession session = httpServletRequest.getSession(false);
+
+			if (session != null) {
+				RenderURL renderURL = actionResponse.createRedirectURL(
+					MimeResponse.Copy.PUBLIC);
+
+				renderURL.setParameter(
+					"mvcRenderCommandName",
+					OpenIdConnectWebKeys.OPEN_ID_CONNECT_REQUEST_ACTION_NAME);
+
+				renderURL.setParameter("saveLastPath", "false");
+
+				session.setAttribute(
+					"OPEN_ID_CONNECT_RENDER_URL", renderURL.toString());
+			}
+
 			_openIdConnectServiceHandler.requestAuthentication(
 				openIdConnectProviderName, httpServletRequest,
 				httpServletResponse);
@@ -92,7 +111,7 @@ public class OpenIdConnectLoginRequestMVCActionCommand
 				SessionErrors.add(actionRequest, e.getClass());
 			}
 			else {
-				_log.error("Unable to process the OpenID login", e);
+				_log.error("Unable to process the OpenID Connect login", e);
 
 				_portal.sendError(e, actionRequest, actionResponse);
 			}

--- a/modules/apps/login/login-authentication-openid-connect-web/src/main/java/com/liferay/login/authentication/openid/connect/web/internal/portlet/action/OpenIdConnectLoginRequestMVCRenderCommand.java
+++ b/modules/apps/login/login-authentication-openid-connect-web/src/main/java/com/liferay/login/authentication/openid/connect/web/internal/portlet/action/OpenIdConnectLoginRequestMVCRenderCommand.java
@@ -14,12 +14,17 @@
 
 package com.liferay.login.authentication.openid.connect.web.internal.portlet.action;
 
+import com.liferay.portal.kernel.exception.UserEmailAddressException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.sso.openid.connect.OpenIdConnect;
 import com.liferay.portal.security.sso.openid.connect.OpenIdConnectProviderRegistry;
@@ -72,8 +77,16 @@ public class OpenIdConnectLoginRequestMVCRenderCommand
 			return "/login.jsp";
 		}
 
-		HttpServletResponse httpServletResponse =
-			_portal.getHttpServletResponse(renderResponse);
+		String error = ParamUtil.getString(renderRequest, "error");
+
+		if (Validator.isNotNull(error)) {
+			if (ArrayUtil.contains(_ERRORS, error)) {
+				SessionErrors.add(renderRequest, error);
+			}
+			else {
+				SessionErrors.add(renderRequest, "unknownError");
+			}
+		}
 
 		Collection<String> openIdConnectProviderNames =
 			_openIdConnectProviderRegistry.getOpenIdConnectProviderNames();
@@ -84,6 +97,9 @@ public class OpenIdConnectLoginRequestMVCRenderCommand
 
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher(_JSP_PATH);
+
+		HttpServletResponse httpServletResponse =
+			_portal.getHttpServletResponse(renderResponse);
 
 		try {
 			requestDispatcher.include(httpServletRequest, httpServletResponse);
@@ -96,6 +112,11 @@ public class OpenIdConnectLoginRequestMVCRenderCommand
 
 		return "/navigation.jsp";
 	}
+
+	private static final String[] _ERRORS = {
+		UserEmailAddressException.MustNotUseCompanyMx.class.getSimpleName(),
+		"StrangersNotAllowedException"
+	};
 
 	private static final String _JSP_PATH =
 		"/com.liferay.login.web/openid_connect.jsp";

--- a/modules/apps/login/login-authentication-openid-connect-web/src/main/resources/META-INF/resources/com.liferay.login.web/openid_connect.jsp
+++ b/modules/apps/login/login-authentication-openid-connect-web/src/main/resources/META-INF/resources/com.liferay.login.web/openid_connect.jsp
@@ -23,6 +23,9 @@
 <aui:form action="<%= openIdConnectURL %>" method="post" name="fm">
 	<aui:input name="saveLastPath" type="hidden" value="<%= false %>" />
 
+	<liferay-ui:error key="MustNotUseCompanyMx" message="the-email-address-associated-with-your-openid-connect-account-cannot-be-used-to-register-a-new-user-because-its-email-domain-is-reserved" />
+	<liferay-ui:error key="StrangersNotAllowedException" message="only-known-users-are-allowed-to-sign-in-using-openid-connect" />
+
 	<aui:select label="openid-connect-provider-name" name="<%= OpenIdConnectWebKeys.OPEN_ID_CONNECT_PROVIDER_NAME %>">
 
 		<%

--- a/modules/apps/login/login-authentication-openid-connect-web/src/main/resources/content/Language.properties
+++ b/modules/apps/login/login-authentication-openid-connect-web/src/main/resources/content/Language.properties
@@ -4,3 +4,5 @@ an-error-occurred-while-parsing-the-token-from-the-openid-connect-provider=An er
 an-error-occurred-while-retrieving-user-info-from-the-openid-connect-provider=An error occurred while retrieving user info from the OpenId Connect provider.
 openid-connect-provider-name=OpenId Connect Provider Name
 unable-to-obtain-user-info-from-the-openid-connect-provider=Unable to obtain user info from the OpenId Connect provider.
+the-email-address-associated-with-your-openid-connect-account-cannot-be-used-to-register-a-new-user-because-its-email-domain-is-reserved=The email address associated with your OpenId Connect account cannot be used to register a new user because its email domain is reserved.
+only-known-users-are-allowed-to-sign-in-using-openid-connect=Only known users are allowed to sign in using OpenId Connect.

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/StrangersNotAllowedException.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/StrangersNotAllowedException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.sso.openid.connect.internal;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Stian Sigvartsen
+ */
+public class StrangersNotAllowedException extends PortalException {
+
+	public StrangersNotAllowedException(long companyId) {
+		super(String.format("Company %s does not allow strangers", companyId));
+
+		this.companyId = companyId;
+	}
+
+	public final long companyId;
+
+}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/service/filter/OpenIdConnectFilter.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/service/filter/OpenIdConnectFilter.java
@@ -72,13 +72,13 @@ public class OpenIdConnectFilter extends BaseFilter {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
+		HttpSession httpSession = httpServletRequest.getSession(false);
+
+		if (httpSession == null) {
+			return;
+		}
+
 		try {
-			HttpSession httpSession = httpServletRequest.getSession(false);
-
-			if (httpSession == null) {
-				return;
-			}
-
 			OpenIdConnectSession openIdConnectSession =
 				(OpenIdConnectSession)httpSession.getAttribute(
 					OpenIdConnectWebKeys.OPEN_ID_CONNECT_SESSION);
@@ -115,11 +115,17 @@ public class OpenIdConnectFilter extends BaseFilter {
 
 			Class<?> clazz = e.getClass();
 
+			httpSession.removeAttribute(
+				OpenIdConnectWebKeys.OPEN_ID_CONNECT_SESSION);
+
 			sendError(
 				clazz.getSimpleName(), httpServletRequest, httpServletResponse);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process the OpenID login", e);
+
+			httpSession.removeAttribute(
+				OpenIdConnectWebKeys.OPEN_ID_CONNECT_SESSION);
 
 			_portal.sendError(e, httpServletRequest, httpServletResponse);
 		}


### PR DESCRIPTION
Following on from https://github.com/stian-sigvartsen/liferay-portal/pull/128

I have squashed the commits from the mentioned pull and applied a new approach to sendError() which does not rely on the FriendlyURLMapper service (which might be replaced) nor complex URL building logic.

The approach uses a session attribute, which should be ok for this SSO because we already rely on another to complete the process.