### PR TITLE
[TECHNICAL-SUPPORT] LPS-86161

### DIFF
--- a/modules/apps/portal-store/portal-store-ignore-duplicates-wrapper/src/main/java/com/liferay/portal/store/ignore/duplicates/wrapper/internal/IgnoreDuplicatesAdvancedFileSystemStoreWrapper.java
+++ b/modules/apps/portal-store/portal-store-ignore-duplicates-wrapper/src/main/java/com/liferay/portal/store/ignore/duplicates/wrapper/internal/IgnoreDuplicatesAdvancedFileSystemStoreWrapper.java
@@ -38,7 +38,7 @@ public class IgnoreDuplicatesAdvancedFileSystemStoreWrapper
 	@Reference(
 		policy = ReferencePolicy.DYNAMIC,
 		policyOption = ReferencePolicyOption.GREEDY,
-		target = "(&(service.ranking<=" + (IgnoreDuplicatesStore.SERVICE_RANKING - 1) + "(store.type=com.liferay.portal.store.file.system.AdvancedFileSystemStore)))"
+		target = "(&(service.ranking<=" + (IgnoreDuplicatesStore.SERVICE_RANKING - 1) + ")(store.type=com.liferay.portal.store.file.system.AdvancedFileSystemStore))"
 	)
 	protected void setStore(Store store) {
 		this.store = store;

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -16,6 +16,8 @@ package com.liferay.portal.dao.orm.hibernate;
 
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONSerializer;
 import com.liferay.portal.kernel.model.BaseModel;
 
 import org.hibernate.Session;
@@ -43,8 +45,14 @@ public class ExceptionTranslator {
 			Object currentObject = session.get(
 				object.getClass(), baseModel.getPrimaryKeyObj());
 
+			JSONSerializer jsonSerializer =
+				JSONFactoryUtil.createJSONSerializer();
+
+			String objStr = jsonSerializer.serialize(object);
+			String currObjStr = jsonSerializer.serialize(currentObject);
+
 			return new ORMException(
-				object + " is stale in comparison to " + currentObject, e);
+				objStr + " is stale in comparison to " + currObjStr, e);
 		}
 
 		return new ORMException(e);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBInspectorUnitTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBInspectorUnitTest.java
@@ -16,8 +16,6 @@ package com.liferay.portal.kernel.dao.db;
 
 import com.liferay.portal.kernel.util.StringUtil;
 
-import com.mysql.jdbc.ResultSetMetaData;
-
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -150,12 +148,6 @@ public class DBInspectorUnitTest {
 		);
 
 		Mockito.when(
-			_resultSet.getMetaData()
-		).thenReturn(
-			_resultSetMetaData
-		);
-
-		Mockito.when(
 			_resultSet.next()
 		).thenReturn(
 			hasColumn
@@ -183,8 +175,5 @@ public class DBInspectorUnitTest {
 
 	@Mock
 	private ResultSet _resultSet;
-
-	@Mock
-	private ResultSetMetaData _resultSetMetaData;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/ServletResponseUtilRangeTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/ServletResponseUtilRangeTest.java
@@ -63,7 +63,6 @@ public class ServletResponseUtilRangeTest extends PowerMockito {
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 
-		setUpBrowserSniffer();
 		setUpFileUtil();
 		setUpPropsUtil();
 	}
@@ -198,18 +197,6 @@ public class ServletResponseUtilRangeTest extends PowerMockito {
 		Assert.assertEquals(range.getStart(), start);
 		Assert.assertEquals(range.getEnd(), end);
 		Assert.assertEquals(range.getLength(), length);
-	}
-
-	protected void setUpBrowserSniffer() {
-		BrowserSnifferUtil browserSnifferUtil = new BrowserSnifferUtil();
-
-		browserSnifferUtil.setBrowserSniffer(_browserSniffer);
-
-		when(
-			_browserSniffer.isIe(Matchers.any(HttpServletRequest.class))
-		).thenReturn(
-			false
-		);
 	}
 
 	protected void setUpFileUtil() {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import javax.servlet.FilterConfig;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -34,25 +33,22 @@ import org.springframework.mock.web.MockHttpServletRequest;
  */
 public class FilterMappingTest {
 
-	@Before
-	public void setUp() {
-		_dispatchers = new ArrayList<>();
-
-		for (Dispatcher dispatcher : Dispatcher.values()) {
-			_dispatchers.add(dispatcher.name());
-		}
-
-		_filterConfig = ProxyFactory.newDummyInstance(FilterConfig.class);
-	}
-
 	@Test
 	public void testIsMatchURLPattern() {
+		List<String> dispatchers = new ArrayList<>();
+
+		for (Dispatcher dispatcher : Dispatcher.values()) {
+			dispatchers.add(dispatcher.name());
+		}
+
 		List<String> urlPatterns = new ArrayList<>();
 
 		urlPatterns.add("/c/portal/login");
 
 		FilterMapping filterMapping = new FilterMapping(
-			StringPool.BLANK, null, _filterConfig, urlPatterns, _dispatchers);
+			StringPool.BLANK, null,
+			ProxyFactory.newDummyInstance(FilterConfig.class), urlPatterns,
+			dispatchers);
 
 		String uri = "/c/portal/login";
 
@@ -64,8 +60,5 @@ public class FilterMappingTest {
 			filterMapping.isMatch(
 				mockHttpServletRequest, Dispatcher.REQUEST, uri));
 	}
-
-	private List<String> _dispatchers;
-	private FilterConfig _filterConfig;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.servlet.HttpMethods;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.servlet.Filter;
 import javax.servlet.FilterConfig;
 
 import org.junit.Assert;
@@ -47,8 +46,6 @@ public class FilterMappingTest extends PowerMockito {
 			_dispatchers.add(dispatcher.name());
 		}
 
-		_filter = mock(Filter.class);
-
 		_filterConfig = mock(FilterConfig.class);
 
 		when(
@@ -71,8 +68,7 @@ public class FilterMappingTest extends PowerMockito {
 		urlPatterns.add("/c/portal/login");
 
 		FilterMapping filterMapping = new FilterMapping(
-			StringPool.BLANK, _filter, _filterConfig, urlPatterns,
-			_dispatchers);
+			StringPool.BLANK, null, _filterConfig, urlPatterns, _dispatchers);
 
 		String uri = "/c/portal/login";
 
@@ -86,7 +82,6 @@ public class FilterMappingTest extends PowerMockito {
 	}
 
 	private List<String> _dispatchers;
-	private Filter _filter;
 	private FilterConfig _filterConfig;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.servlet.filters.invoker;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.util.ProxyFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,18 +26,13 @@ import javax.servlet.FilterConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * @author Mika Koivisto
  */
-@RunWith(PowerMockRunner.class)
-public class FilterMappingTest extends PowerMockito {
+public class FilterMappingTest {
 
 	@Before
 	public void setUp() {
@@ -46,19 +42,7 @@ public class FilterMappingTest extends PowerMockito {
 			_dispatchers.add(dispatcher.name());
 		}
 
-		_filterConfig = mock(FilterConfig.class);
-
-		when(
-			_filterConfig.getInitParameter("url-regex-pattern")
-		).thenReturn(
-			StringPool.BLANK
-		);
-
-		when(
-			_filterConfig.getInitParameter("url-regex-ignore-pattern")
-		).thenReturn(
-			StringPool.BLANK
-		);
+		_filterConfig = ProxyFactory.newDummyInstance(FilterConfig.class);
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
@@ -35,20 +35,21 @@ public class FilterMappingTest {
 
 	@Test
 	public void testIsMatchURLPattern() {
-		List<String> dispatchers = new ArrayList<>();
-
-		for (Dispatcher dispatcher : Dispatcher.values()) {
-			dispatchers.add(dispatcher.name());
-		}
-
-		List<String> urlPatterns = new ArrayList<>();
-
-		urlPatterns.add("/c/portal/login");
-
 		FilterMapping filterMapping = new FilterMapping(
 			StringPool.BLANK, null,
-			ProxyFactory.newDummyInstance(FilterConfig.class), urlPatterns,
-			dispatchers);
+			ProxyFactory.newDummyInstance(FilterConfig.class),
+			new ArrayList<String>() {
+				{
+					add("/c/portal/login");
+				}
+			},
+			new ArrayList<String>() {
+				{
+					for (Dispatcher dispatcher : Dispatcher.values()) {
+						add(dispatcher.name());
+					}
+				}
+			});
 
 		String uri = "/c/portal/login";
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/ConfigurationBeanSettingsTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/ConfigurationBeanSettingsTest.java
@@ -18,21 +18,20 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.powermock.api.mockito.PowerMockito;
-
 /**
  * @author Iván Zaera
  */
-public class ConfigurationBeanSettingsTest extends PowerMockito {
+public class ConfigurationBeanSettingsTest {
 
 	@Before
 	public void setUp() {
 		_configurationBean = new ConfigurationBean();
 
-		_mockLocationVariableResolver = mock(LocationVariableResolver.class);
+		_locationVariableResolver = new LocationVariableResolver(
+			null, (SettingsLocatorHelper)null);
 
 		_configurationBeanSettings = new ConfigurationBeanSettings(
-			_mockLocationVariableResolver, _configurationBean, null);
+			_locationVariableResolver, _configurationBean, null);
 	}
 
 	@Test
@@ -79,25 +78,42 @@ public class ConfigurationBeanSettingsTest extends PowerMockito {
 
 	@Test
 	public void testGetValueWithLocationVariable() {
-		when(
-			_mockLocationVariableResolver.isLocationVariable(
-				_configurationBean.locationVariableValue())
-		).thenReturn(
-			true
-		);
-
 		String expectedValue = "Once upon a time...";
 
-		when(
-			_mockLocationVariableResolver.resolve(
-				_configurationBean.locationVariableValue())
-		).thenReturn(
-			expectedValue
-		);
+		LocationVariableResolver locationVariableResolver =
+			new LocationVariableResolver(null, (SettingsLocatorHelper)null) {
+
+				@Override
+				public boolean isLocationVariable(String value) {
+					if (value.equals(
+							_configurationBean.locationVariableValue())) {
+
+						return true;
+					}
+
+					return false;
+				}
+
+				@Override
+				public String resolve(String value) {
+					if (value.equals(
+							_configurationBean.locationVariableValue())) {
+
+						return expectedValue;
+					}
+
+					return null;
+				}
+
+			};
+
+		ConfigurationBeanSettings configurationBeanSettings =
+			new ConfigurationBeanSettings(
+				locationVariableResolver, _configurationBean, null);
 
 		Assert.assertEquals(
 			expectedValue,
-			_configurationBeanSettings.getValue(
+			configurationBeanSettings.getValue(
 				"locationVariableValue", "defaultValue"));
 	}
 
@@ -112,7 +128,7 @@ public class ConfigurationBeanSettingsTest extends PowerMockito {
 	public void testGetValueWithNullConfigurationBean() {
 		try {
 			_configurationBeanSettings = new ConfigurationBeanSettings(
-				_mockLocationVariableResolver, null, null);
+				_locationVariableResolver, null, null);
 
 			Assert.fail();
 		}
@@ -137,7 +153,7 @@ public class ConfigurationBeanSettingsTest extends PowerMockito {
 
 	private ConfigurationBean _configurationBean;
 	private ConfigurationBeanSettings _configurationBeanSettings;
-	private LocationVariableResolver _mockLocationVariableResolver;
+	private LocationVariableResolver _locationVariableResolver;
 
 	private static class ConfigurationBean {
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/LocationVariableResolverTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/LocationVariableResolverTest.java
@@ -14,10 +14,8 @@
 
 package com.liferay.portal.kernel.settings;
 
-import com.liferay.portal.kernel.util.FileUtil;
-//import com.liferay.portal.util.FileImpl;
-
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 import java.util.List;
@@ -37,10 +35,6 @@ public class LocationVariableResolverTest extends PowerMockito {
 
 	@Before
 	public void setUp() throws Exception {
-		FileUtil fileUtil = new FileUtil();
-
-		fileUtil.setFile(new MockFile());
-
 		_mockResourceManager = new MockResourceManager(
 			"En un lugar de la Mancha...");
 
@@ -70,14 +64,17 @@ public class LocationVariableResolverTest extends PowerMockito {
 
 		File file = File.createTempFile("testResolveVariableForFile", "txt");
 
-		file.deleteOnExit();
+		try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+			fileOutputStream.write(expectedValue.getBytes());
 
-		FileUtil.write(file, expectedValue.getBytes());
+			String value = _locationVariableResolver.resolve(
+				"${file://" + file.getAbsolutePath() + "}");
 
-		String value = _locationVariableResolver.resolve(
-			"${file://" + file.getAbsolutePath() + "}");
-
-		Assert.assertEquals(expectedValue, value);
+			Assert.assertEquals(expectedValue, value);
+		}
+		finally {
+			file.delete();
+		}
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/LocationVariableResolverTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/LocationVariableResolverTest.java
@@ -66,6 +66,8 @@ public class LocationVariableResolverTest extends PowerMockito {
 		try (OutputStream outputStream = new FileOutputStream(file)) {
 			outputStream.write(expectedValue.getBytes());
 
+			outputStream.flush();
+
 			String value = _locationVariableResolver.resolve(
 				"${file://" + file.getAbsolutePath() + "}");
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/LocationVariableResolverTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/LocationVariableResolverTest.java
@@ -24,8 +24,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.Matchers;
-
 import org.powermock.api.mockito.PowerMockito;
 
 /**
@@ -100,21 +98,16 @@ public class LocationVariableResolverTest extends PowerMockito {
 
 	@Test
 	public void testResolveVariableWithServerProperty() {
-		Settings mockSettings = mock(Settings.class);
-
 		final String expectedValue = "test@liferay.com";
 
-		when(
-			mockSettings.getValue(
-				Matchers.eq("admin.email.from.address"), Matchers.anyString())
-		).thenReturn(
-			expectedValue
-		);
+		MemorySettings memorySettings = new MemorySettings();
+
+		memorySettings.setValue("admin.email.from.address", expectedValue);
 
 		when(
 			_mockSettingsLocatorHelper.getServerSettings("com.liferay.portal")
 		).thenReturn(
-			mockSettings
+			memorySettings
 		);
 
 		Assert.assertEquals(

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/LocationVariableResolverTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/LocationVariableResolverTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.settings;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 
 import java.util.List;
 
@@ -62,8 +63,8 @@ public class LocationVariableResolverTest extends PowerMockito {
 
 		File file = File.createTempFile("testResolveVariableForFile", "txt");
 
-		try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
-			fileOutputStream.write(expectedValue.getBytes());
+		try (OutputStream outputStream = new FileOutputStream(file)) {
+			outputStream.write(expectedValue.getBytes());
 
 			String value = _locationVariableResolver.resolve(
 				"${file://" + file.getAbsolutePath() + "}");

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/PropertiesSettingsTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/PropertiesSettingsTest.java
@@ -23,12 +23,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.powermock.api.mockito.PowerMockito;
-
 /**
  * @author Iván Zaera
  */
-public class PropertiesSettingsTest extends PowerMockito {
+public class PropertiesSettingsTest {
 
 	@Before
 	public void setUp() {
@@ -37,10 +35,9 @@ public class PropertiesSettingsTest extends PowerMockito {
 		properties.put(_SINGLE_KEY, _SINGLE_VALUE);
 		properties.put(_MULTIPLE_KEY, _MULTIPLE_VALUES);
 
-		_mockLocationVariableResolver = mock(LocationVariableResolver.class);
-
 		_propertiesSettings = new PropertiesSettings(
-			_mockLocationVariableResolver, properties);
+			new LocationVariableResolver(null, (SettingsLocatorHelper)null),
+			properties);
 
 		_properties = ReflectionTestUtil.getFieldValue(
 			_propertiesSettings, "_properties");
@@ -70,27 +67,21 @@ public class PropertiesSettingsTest extends PowerMockito {
 
 	@Test
 	public void testGetValuesWithResourceValue() {
-		_properties.put(_MULTIPLE_KEY, _RESOURCE_MULTIPLE_VALUES);
-
-		when(
-			_mockLocationVariableResolver.isLocationVariable(
-				_RESOURCE_MULTIPLE_VALUES)
-		).thenReturn(
-			true
-		);
-
 		final String expectedValue =
 			"resourceValue0,resourceValue1,resourceValue2";
 
-		when(
-			_mockLocationVariableResolver.resolve(_RESOURCE_MULTIPLE_VALUES)
-		).thenReturn(
-			expectedValue
-		);
+		Properties properties = new Properties();
+
+		properties.put(_MULTIPLE_KEY, _RESOURCE_MULTIPLE_VALUES);
+
+		PropertiesSettings propertiesSettings = new PropertiesSettings(
+			_createLocationVariableResolver(
+				_RESOURCE_MULTIPLE_VALUES, expectedValue),
+			properties);
 
 		Assert.assertArrayEquals(
 			expectedValue.split(","),
-			_propertiesSettings.getValues(_MULTIPLE_KEY, null));
+			propertiesSettings.getValues(_MULTIPLE_KEY, null));
 	}
 
 	@Test
@@ -113,25 +104,45 @@ public class PropertiesSettingsTest extends PowerMockito {
 
 	@Test
 	public void testGetValueWithResourceValue() {
-		_properties.put(_SINGLE_KEY, _RESOURCE_SINGLE_VALUE);
-
-		when(
-			_mockLocationVariableResolver.isLocationVariable(
-				_RESOURCE_SINGLE_VALUE)
-		).thenReturn(
-			true
-		);
-
 		final String expectedValue = "resourceValue";
 
-		when(
-			_mockLocationVariableResolver.resolve(_RESOURCE_SINGLE_VALUE)
-		).thenReturn(
-			expectedValue
-		);
+		Properties properties = new Properties();
+
+		properties.put(_SINGLE_KEY, _RESOURCE_SINGLE_VALUE);
+
+		PropertiesSettings propertiesSettings = new PropertiesSettings(
+			_createLocationVariableResolver(
+				_RESOURCE_SINGLE_VALUE, expectedValue),
+			properties);
 
 		Assert.assertEquals(
-			expectedValue, _propertiesSettings.getValue(_SINGLE_KEY, null));
+			expectedValue, propertiesSettings.getValue(_SINGLE_KEY, null));
+	}
+
+	private LocationVariableResolver _createLocationVariableResolver(
+		String resolveString, String expectedValue) {
+
+		return new LocationVariableResolver(null, (SettingsLocatorHelper)null) {
+
+			@Override
+			public boolean isLocationVariable(String value) {
+				if (value.equals(resolveString)) {
+					return true;
+				}
+
+				return false;
+			}
+
+			@Override
+			public String resolve(String value) {
+				if (value.equals(resolveString)) {
+					return expectedValue;
+				}
+
+				return null;
+			}
+
+		};
 	}
 
 	private static final String _MULTIPLE_KEY = "multipleKey";
@@ -148,7 +159,6 @@ public class PropertiesSettingsTest extends PowerMockito {
 
 	private static final String _SINGLE_VALUE = "value";
 
-	private LocationVariableResolver _mockLocationVariableResolver;
 	private Map<String, String> _properties;
 	private PropertiesSettings _propertiesSettings;
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/PropertiesSettingsTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/PropertiesSettingsTest.java
@@ -30,16 +30,14 @@ public class PropertiesSettingsTest {
 
 	@Before
 	public void setUp() {
-		Properties properties = new Properties() {
-			{
-				put(_SINGLE_KEY, _SINGLE_VALUE);
-				put(_MULTIPLE_KEY, _MULTIPLE_VALUES);
-			}
-		};
-
 		_propertiesSettings = new PropertiesSettings(
 			new LocationVariableResolver(null, (SettingsLocatorHelper)null),
-			properties);
+			new Properties() {
+				{
+					put(_SINGLE_KEY, _SINGLE_VALUE);
+					put(_MULTIPLE_KEY, _MULTIPLE_VALUES);
+				}
+			});
 
 		_properties = ReflectionTestUtil.getFieldValue(
 			_propertiesSettings, "_properties");
@@ -72,16 +70,14 @@ public class PropertiesSettingsTest {
 		final String expectedValue =
 			"resourceValue0,resourceValue1,resourceValue2";
 
-		Properties properties = new Properties() {
-			{
-				put(_MULTIPLE_KEY, _RESOURCE_MULTIPLE_VALUES);
-			}
-		};
-
 		PropertiesSettings propertiesSettings = new PropertiesSettings(
 			_createLocationVariableResolver(
 				_RESOURCE_MULTIPLE_VALUES, expectedValue),
-			properties);
+			new Properties() {
+				{
+					put(_MULTIPLE_KEY, _RESOURCE_MULTIPLE_VALUES);
+				}
+			});
 
 		Assert.assertArrayEquals(
 			expectedValue.split(","),
@@ -110,16 +106,14 @@ public class PropertiesSettingsTest {
 	public void testGetValueWithResourceValue() {
 		final String expectedValue = "resourceValue";
 
-		Properties properties = new Properties() {
-			{
-				put(_SINGLE_KEY, _RESOURCE_SINGLE_VALUE);
-			}
-		};
-
 		PropertiesSettings propertiesSettings = new PropertiesSettings(
 			_createLocationVariableResolver(
 				_RESOURCE_SINGLE_VALUE, expectedValue),
-			properties);
+			new Properties() {
+				{
+					put(_SINGLE_KEY, _RESOURCE_SINGLE_VALUE);
+				}
+			});
 
 		Assert.assertEquals(
 			expectedValue, propertiesSettings.getValue(_SINGLE_KEY, null));

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/PropertiesSettingsTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/PropertiesSettingsTest.java
@@ -30,10 +30,12 @@ public class PropertiesSettingsTest {
 
 	@Before
 	public void setUp() {
-		Properties properties = new Properties();
-
-		properties.put(_SINGLE_KEY, _SINGLE_VALUE);
-		properties.put(_MULTIPLE_KEY, _MULTIPLE_VALUES);
+		Properties properties = new Properties() {
+			{
+				put(_SINGLE_KEY, _SINGLE_VALUE);
+				put(_MULTIPLE_KEY, _MULTIPLE_VALUES);
+			}
+		};
 
 		_propertiesSettings = new PropertiesSettings(
 			new LocationVariableResolver(null, (SettingsLocatorHelper)null),
@@ -70,9 +72,11 @@ public class PropertiesSettingsTest {
 		final String expectedValue =
 			"resourceValue0,resourceValue1,resourceValue2";
 
-		Properties properties = new Properties();
-
-		properties.put(_MULTIPLE_KEY, _RESOURCE_MULTIPLE_VALUES);
+		Properties properties = new Properties() {
+			{
+				put(_MULTIPLE_KEY, _RESOURCE_MULTIPLE_VALUES);
+			}
+		};
 
 		PropertiesSettings propertiesSettings = new PropertiesSettings(
 			_createLocationVariableResolver(
@@ -106,9 +110,11 @@ public class PropertiesSettingsTest {
 	public void testGetValueWithResourceValue() {
 		final String expectedValue = "resourceValue";
 
-		Properties properties = new Properties();
-
-		properties.put(_SINGLE_KEY, _RESOURCE_SINGLE_VALUE);
+		Properties properties = new Properties() {
+			{
+				put(_SINGLE_KEY, _RESOURCE_SINGLE_VALUE);
+			}
+		};
 
 		PropertiesSettings propertiesSettings = new PropertiesSettings(
 			_createLocationVariableResolver(

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/DateUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/DateUtilTest.java
@@ -25,7 +25,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -147,7 +146,7 @@ public class DateUtilTest extends PowerMockito {
 		);
 
 		Assert.assertEquals(
-			expected, DateUtil.getDaysBetween(date1, date2, _timeZone));
+			expected, DateUtil.getDaysBetween(date1, date2, null));
 	}
 
 	private void _testGetISOFormat(String text, String pattern) {
@@ -191,9 +190,6 @@ public class DateUtilTest extends PowerMockito {
 
 		Assert.assertEquals(testSimpleDateFormat.getPattern(), pattern);
 	}
-
-	@Mock
-	private TimeZone _timeZone;
 
 	private static class TestSimpleDateFormat extends SimpleDateFormat {
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/DateUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/DateUtilTest.java
@@ -88,7 +88,7 @@ public class DateUtilTest extends PowerMockito {
 
 	@Test
 	public void testGetISOFormatAny() {
-		_testGetISOFormat(Mockito.anyString(), "yyyyMMddHHmmssz");
+		_testGetISOFormat("", "yyyyMMddHHmmssz");
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/LocaleUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/LocaleUtilTest.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,11 +37,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest(LanguageUtil.class)
 @RunWith(PowerMockRunner.class)
 public class LocaleUtilTest extends PowerMockito {
-
-	@After
-	public void tearDown() {
-		verifyStatic();
-	}
 
 	@Test
 	public void testFromLanguageId() {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/comparator/PortletCategoryComparatorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/comparator/PortletCategoryComparatorTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.PortletCategory;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.ProxyFactory;
 
 import java.util.Locale;
 
@@ -44,13 +45,7 @@ public class PortletCategoryComparatorTest extends PowerMockito {
 
 	@Before
 	public void setUp() {
-		when(
-			_props.get(Matchers.anyString())
-		).thenReturn(
-			null
-		);
-
-		PropsUtil.setProps(_props);
+		PropsUtil.setProps(ProxyFactory.newDummyInstance(Props.class));
 
 		setUpLanguageUtil();
 	}
@@ -88,8 +83,5 @@ public class PortletCategoryComparatorTest extends PowerMockito {
 
 	@Mock
 	private Language _language;
-
-	@Mock
-	private Props _props;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
@@ -16,11 +16,14 @@ package com.liferay.portal.service.permission;
 
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.model.RoleWrapper;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceWrapper;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 
@@ -34,8 +37,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.mockito.Mockito;
-
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -45,79 +46,41 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Jorge Ferrer
  */
-@PrepareForTest({ResourceActionsUtil.class, RoleLocalServiceUtil.class})
+@PrepareForTest(ResourceActionsUtil.class)
 @RunWith(PowerMockRunner.class)
 public class ModelPermissionsFactoryTest extends PowerMockito {
 
 	@Before
 	public void setUp() throws Exception {
-		mockStatic(RoleLocalServiceUtil.class);
+		ReflectionTestUtil.setFieldValue(
+			RoleLocalServiceUtil.class, "_service",
+			new RoleLocalServiceWrapper(null) {
 
-		Role guestRole = Mockito.mock(Role.class);
+				@Override
+				public Role getDefaultGroupRole(long groupId) {
+					return new RoleWrapper(null) {
 
-		Mockito.when(
-			guestRole.getName()
-		).thenReturn(
-			RoleConstants.GUEST
-		);
+						@Override
+						public String getName() {
+							return RoleConstants.SITE_MEMBER;
+						}
 
-		when(
-			RoleLocalServiceUtil.getRole(
-				Mockito.anyLong(), Mockito.eq(RoleConstants.GUEST))
-		).thenReturn(
-			guestRole
-		);
+					};
+				}
 
-		Role organizationUserRole = Mockito.mock(Role.class);
+				@Override
+				public Role getRole(long companyId, String name) {
+					return new RoleWrapper(null) {
 
-		Mockito.when(
-			organizationUserRole.getName()
-		).thenReturn(
-			RoleConstants.ORGANIZATION_USER
-		);
+						@Override
+						public String getName() {
+							return name;
+						}
 
-		when(
-			RoleLocalServiceUtil.getRole(
-				Mockito.anyLong(), Mockito.eq(RoleConstants.ORGANIZATION_USER))
-		).thenReturn(
-			organizationUserRole
-		);
+					};
+				}
 
-		Role powerUserRole = Mockito.mock(Role.class);
-
-		Mockito.when(
-			powerUserRole.getName()
-		).thenReturn(
-			RoleConstants.POWER_USER
-		);
-
-		when(
-			RoleLocalServiceUtil.getRole(
-				Mockito.anyLong(), Mockito.eq(RoleConstants.POWER_USER))
-		).thenReturn(
-			powerUserRole
-		);
-
-		Role siteMemberRole = Mockito.mock(Role.class);
-
-		Mockito.when(
-			siteMemberRole.getName()
-		).thenReturn(
-			RoleConstants.SITE_MEMBER
-		);
-
-		when(
-			RoleLocalServiceUtil.getDefaultGroupRole(Mockito.anyLong())
-		).thenReturn(
-			siteMemberRole
-		);
-
-		when(
-			RoleLocalServiceUtil.getRole(
-				Mockito.anyLong(), Mockito.eq(RoleConstants.SITE_MEMBER))
-		).thenReturn(
-			siteMemberRole
-		);
+			});
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,8 +50,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 @RunWith(PowerMockRunner.class)
 public class ModelPermissionsFactoryTest extends PowerMockito {
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
 		ReflectionTestUtil.setFieldValue(
 			RoleLocalServiceUtil.class, "_service",
 			new RoleLocalServiceWrapper(null) {

--- a/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ProxyFactory;
@@ -96,17 +97,13 @@ public class SubscriptionSenderTest extends PowerMockito {
 
 		PortalBeanLocatorUtil.setBeanLocator(_beanLocator);
 
-		PortalUUIDUtil portalUUIDUtil = new PortalUUIDUtil();
+		ReflectionTestUtil.setFieldValue(
+			PortalUUIDUtil.class, "_portalUUID",
+			ProxyFactory.newDummyInstance(PortalUUID.class));
 
-		PortalUUID portalUUID = ProxyFactory.newDummyInstance(PortalUUID.class);
-
-		portalUUIDUtil.setPortalUUID(portalUUID);
-
-		PortalUtil portalUtil = new PortalUtil();
-
-		Portal portal = ProxyFactory.newDummyInstance(Portal.class);
-
-		portalUtil.setPortal(portal);
+		ReflectionTestUtil.setFieldValue(
+			PortalUtil.class, "_portal",
+			ProxyFactory.newDummyInstance(Portal.class));
 	}
 
 	@After

--- a/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.ProxyFactory;
 import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.uuid.PortalUUID;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
@@ -97,13 +98,13 @@ public class SubscriptionSenderTest extends PowerMockito {
 
 		PortalUUIDUtil portalUUIDUtil = new PortalUUIDUtil();
 
-		PortalUUID portalUUID = mock(PortalUUID.class);
+		PortalUUID portalUUID = ProxyFactory.newDummyInstance(PortalUUID.class);
 
 		portalUUIDUtil.setPortalUUID(portalUUID);
 
 		PortalUtil portalUtil = new PortalUtil();
 
-		Portal portal = mock(Portal.class);
+		Portal portal = ProxyFactory.newDummyInstance(Portal.class);
 
 		portalUtil.setPortal(portal);
 	}

--- a/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
@@ -25,8 +25,6 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.Props;
-import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.uuid.PortalUUID;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
@@ -108,10 +106,6 @@ public class SubscriptionSenderTest extends PowerMockito {
 		Portal portal = mock(Portal.class);
 
 		portalUtil.setPortal(portal);
-
-		Props props = mock(Props.class);
-
-		PropsUtil.setProps(props);
 	}
 
 	@After

--- a/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
@@ -111,15 +111,12 @@ public class SubscriptionSenderTest {
 
 		PortalUUIDUtil portalUUIDUtil = new PortalUUIDUtil();
 
-		PortalUUID portalUUID = ProxyFactory.newDummyInstance(PortalUUID.class);
-
-		portalUUIDUtil.setPortalUUID(portalUUID);
+		portalUUIDUtil.setPortalUUID(
+			ProxyFactory.newDummyInstance(PortalUUID.class));
 
 		PortalUtil portalUtil = new PortalUtil();
 
-		Portal portal = ProxyFactory.newDummyInstance(Portal.class);
-
-		portalUtil.setPortal(portal);
+		portalUtil.setPortal(ProxyFactory.newDummyInstance(Portal.class));
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
@@ -31,9 +31,8 @@ import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.uuid.PortalUUID;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -41,8 +40,8 @@ import org.junit.Test;
  */
 public class SubscriptionSenderTest {
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
 		ReflectionTestUtil.setFieldValue(
 			CompanyLocalServiceUtil.class, "_service",
 			new CompanyLocalServiceWrapper(null) {
@@ -117,14 +116,6 @@ public class SubscriptionSenderTest {
 		ReflectionTestUtil.setFieldValue(
 			PortalUtil.class, "_portal",
 			ProxyFactory.newDummyInstance(Portal.class));
-	}
-
-	@After
-	public void tearDown() {
-		ReflectionTestUtil.setFieldValue(
-			CompanyLocalServiceUtil.class, "_service", null);
-		ReflectionTestUtil.setFieldValue(
-			GroupLocalServiceUtil.class, "_service", null);
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/util/SubscriptionSenderTest.java
@@ -109,13 +109,17 @@ public class SubscriptionSenderTest {
 
 			});
 
-		ReflectionTestUtil.setFieldValue(
-			PortalUUIDUtil.class, "_portalUUID",
-			ProxyFactory.newDummyInstance(PortalUUID.class));
+		PortalUUIDUtil portalUUIDUtil = new PortalUUIDUtil();
 
-		ReflectionTestUtil.setFieldValue(
-			PortalUtil.class, "_portal",
-			ProxyFactory.newDummyInstance(Portal.class));
+		PortalUUID portalUUID = ProxyFactory.newDummyInstance(PortalUUID.class);
+
+		portalUUIDUtil.setPortalUUID(portalUUID);
+
+		PortalUtil portalUtil = new PortalUtil();
+
+		Portal portal = ProxyFactory.newDummyInstance(Portal.class);
+
+		portalUtil.setPortal(portal);
 	}
 
 	@Test

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ProductMenu.macro
@@ -1,46 +1,4 @@
 <definition>
-	<command name="gotoControlPanelConfiguration" summary="Navigate to Product Menu > Control Panel > Configuration > ${portlet}">
-		<execute macro="ProductMenuHelper#expandPanel">
-			<var name="panel" value="Control Panel" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#expandCategory">
-			<var name="category" value="Configuration" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#gotoPortlet">
-			<var name="portlet" value="${portlet}" />
-		</execute>
-	</command>
-
-	<command name="gotoControlPanelSites" summary="Navigate to Product Menu > Control Panel > Sites > ${portlet}">
-		<execute macro="ProductMenuHelper#expandPanel">
-			<var name="panel" value="Control Panel" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#expandCategory">
-			<var name="category" value="Sites" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#gotoPortlet">
-			<var name="portlet" value="${portlet}" />
-		</execute>
-	</command>
-
-	<command name="gotoControlPanelUsers" summary="Navigate to Product Menu > Control Panel > Users > ${portlet}">
-		<execute macro="ProductMenuHelper#expandPanel">
-			<var name="panel" value="Control Panel" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#expandCategory">
-			<var name="category" value="Users" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#gotoPortlet">
-			<var name="portlet" value="${portlet}" />
-		</execute>
-	</command>
-
 	<command name="gotoLiveSite" summary="Navigate to the Live site">
 		<execute macro="ProductMenuHelper#expandPanel">
 			<var name="panel" value="Site Administration" />
@@ -129,48 +87,6 @@
 		<execute function="AssertTextEquals#assertPartialText" locator1="ProductMenu#PRODUCT_MENU_PANEL_SITE_ADMINISTRATION_SITE_NAME" value1="${site}" />
 	</command>
 
-	<command name="gotoSitesConfiguration" summary="Navigate to Product Menu > Sites > Configuration > ${portlet}">
-		<execute macro="ProductMenuHelper#expandPanel">
-			<var name="panel" value="Site Administration" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#expandCategory">
-			<var name="category" value="Configuration" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#gotoPortlet">
-			<var name="portlet" value="${portlet}" />
-		</execute>
-	</command>
-
-	<command name="gotoSitesContent" summary="Navigate to Product Menu > Sites > Content > ${portlet}">
-		<execute macro="ProductMenuHelper#expandPanel">
-			<var name="panel" value="Site Administration" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#expandCategory">
-			<var name="category" value="Content" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#gotoPortlet">
-			<var name="portlet" value="${portlet}" />
-		</execute>
-	</command>
-
-	<command name="gotoSitesMembers" summary="Navigate to Product Menu > Sites > Members > ${portlet}">
-		<execute macro="ProductMenuHelper#expandPanel">
-			<var name="panel" value="Site Administration" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#expandCategory">
-			<var name="category" value="Members" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#gotoPortlet">
-			<var name="portlet" value="${portlet}" />
-		</execute>
-	</command>
-
 	<command name="gotoSiteViaLink" summary="Navigate to ${site} via the 'Go to Site' link">
 		<execute macro="ProductMenuHelper#expandPanel">
 			<var name="panel" value="Site Administration" />
@@ -192,20 +108,6 @@
 		</if>
 
 		<execute function="AssertVisible" locator1="ProductMenu#STAGING_SELECTED" />
-	</command>
-
-	<command name="gotoUserMyAccount" summary="Navigate to Product Menu > User > My Account > ${portlet}">
-		<execute macro="ProductMenuHelper#expandPanel">
-			<var name="panel" value="User" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#expandCategory">
-			<var name="category" value="My Account" />
-		</execute>
-
-		<execute macro="ProductMenuHelper#gotoPortlet">
-			<var name="portlet" value="${portlet}" />
-		</execute>
 	</command>
 
 	<command name="viewNoSite" summary="View ${site} is not available in the product menu.">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/ClassicSearch.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/ClassicSearch.testcase
@@ -617,7 +617,9 @@
 	</command>
 
 	<command name="ViewSearchResultForLongURL" priority="4">
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Documents and Media" />
 		</execute>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentlibrarystore/DocumentLibraryStore.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentlibrarystore/DocumentLibraryStore.testcase
@@ -45,7 +45,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Documents and Media" />
 		</execute>
 
@@ -77,7 +79,9 @@
 
 		<execute function="AssertConsoleTextNotPresent" value1="java.lang.IllegalStateException: Store is not available" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Documents and Media" />
 		</execute>
 
@@ -109,7 +113,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Documents and Media" />
 		</execute>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
@@ -68,7 +68,9 @@
 
 			<execute macro="Form#save" />
 
-			<execute macro="ProductMenu#gotoSitesContent">
+			<execute macro="ProductMenu#gotoPortlet">
+				<var name="category" value="Content" />
+				<var name="panel" value="Site Administration" />
 				<var name="portlet" value="Forms" />
 			</execute>
 		</for>
@@ -77,7 +79,9 @@
 	<command name="Add30Fields" priority="4">
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -518,7 +522,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoControlPanelUsers">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Users" />
+			<var name="panel" value="Control Panel" />
 			<var name="portlet" value="Users and Organizations" />
 		</execute>
 
@@ -529,7 +535,9 @@
 			<var name="userScreenName" value="usersn" />
 		</execute>
 
-		<execute macro="ProductMenu#gotoControlPanelUsers">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Users" />
+			<var name="panel" value="Control Panel" />
 			<var name="portlet" value="Users and Organizations" />
 		</execute>
 
@@ -538,7 +546,9 @@
 			<var name="userScreenName" value="usersn" />
 		</execute>
 
-		<execute macro="ProductMenu#gotoControlPanelSites">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Sites" />
+			<var name="panel" value="Control Panel" />
 			<var name="portlet" value="Sites" />
 		</execute>
 
@@ -546,7 +556,9 @@
 			<var name="siteName" value="Form Site" />
 		</execute>
 
-		<execute macro="ProductMenu#gotoSitesMembers">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Members" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Site Memberships" />
 		</execute>
 
@@ -584,7 +596,9 @@
 			<var name="roleType" value="site" />
 		</execute>
 
-		<execute macro="ProductMenu#gotoControlPanelUsers">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Users" />
+			<var name="panel" value="Control Panel" />
 			<var name="portlet" value="Users and Organizations" />
 		</execute>
 
@@ -602,7 +616,9 @@
 			<var name="site" value="Form Site" />
 		</execute>
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -624,7 +640,9 @@
 
 		<execute macro="Form#save" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -638,7 +656,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -1157,7 +1177,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoControlPanelConfiguration">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Configuration" />
+			<var name="panel" value="Control Panel" />
 			<var name="portlet" value="System Settings" />
 		</execute>
 
@@ -1179,7 +1201,9 @@
 
 		<execute macro="SystemSettings#saveConfiguration" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -1400,7 +1424,9 @@
 	<command name="DeletePages" priority="5">
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -1573,7 +1599,9 @@
 	<command name="DeleteSelectFromListOptionValue" priority="3">
 		<description message="This is a use case for LPS-68362." />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -2181,7 +2209,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -2203,7 +2233,9 @@
 
 		<execute macro="Form#save" />
 
-		<execute macro="ProductMenu#gotoUserMyAccount">
+		<execute macro="ProductMenu#gotoSite">
+			<var name="category" value="My Account" />
+			<var name="panel" value="User" />
 			<var name="portlet" value="Account Settings" />
 		</execute>
 
@@ -2242,7 +2274,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesConfiguration">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Configuration" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Site Settings" />
 		</execute>
 
@@ -2251,7 +2285,9 @@
 			<var name="displaySettings" value="Display Settings" />
 		</execute>
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -2273,7 +2309,9 @@
 	<command name="EditTranslatedGridField" priority="4">
 		<description message="This is a use case for LPS-78697." />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -2629,7 +2667,9 @@
 	<command name="ReorderFieldOptions" priority="3">
 		<description message="This is a use case for LPS-68381." />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -2849,7 +2889,9 @@
 	<command name="SelectAndRemoveMultipleOptionsInSelectFromListField" priority="4">
 		<description message="This is a use case for LPS-76079." />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -5022,7 +5064,9 @@
 	<command name="SubmitWithRequiredDateField" priority="4">
 		<description message="This is a use case for LPS-73322." />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -5080,7 +5124,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -5380,7 +5426,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -5474,7 +5522,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsDataProvider.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsDataProvider.testcase
@@ -28,7 +28,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -57,7 +59,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -90,7 +94,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -156,7 +162,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 
@@ -169,7 +177,9 @@
 
 		<execute macro="Navigator#openURL" />
 
-		<execute macro="ProductMenu#gotoSitesContent">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
 			<var name="portlet" value="Forms" />
 		</execute>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/workflow/WorkflowDocumentsAndMedia.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/workflow/WorkflowDocumentsAndMedia.testcase
@@ -63,7 +63,9 @@
 			<var name="orgName" value="Space Program Academy of Continuing Education" />
 		</execute>
 
-		<execute macro="ProductMenu#gotoControlPanelSites">
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Sites" />
+			<var name="panel" value="Control Panel" />
 			<var name="portlet" value="Sites" />
 		</execute>
 
@@ -297,7 +299,9 @@
 		</execute>
 
 		<for list="1,2,3" param="entryCount">
-			<execute macro="ProductMenu#gotoSitesContent">
+			<execute macro="ProductMenu#gotoPortlet">
+				<var name="category" value="Content" />
+				<var name="panel" value="Site Administration" />
 				<var name="portlet" value="Documents and Media" />
 			</execute>
 


### PR DESCRIPTION
/cc @ricky-pan 

Relevant tickets:
https://issues.liferay.com/browse/LPS-86161
https://issues.liferay.com/browse/LPP-31875

Notes from Ricky:

> Issue: StaleObjectStateExceptions currently log the entire object from the database, because it calls the object's `toString()` method. This is an issue because not all parties have the same understanding of safe logging, and this does not allow for an easy way to change what is logged.
> 
> Solution: Serialize an object using Liferay's JSONSerializer, which omits field that are hidden from json-services when building services. Fields that are not available to a user with highest permission when calling JSON Web Services should not be accessible within the logs, so this will standardize how models are printed.