### PR TITLE
LPS-86000 Google SSO must respect the portal's stranger policy

### DIFF
--- a/modules/apps/login/login-authentication-google-web/src/main/java/com/liferay/login/authentication/google/web/internal/portlet/action/GoogleLoginAction.java
+++ b/modules/apps/login/login-authentication-google-web/src/main/java/com/liferay/login/authentication/google/web/internal/portlet/action/GoogleLoginAction.java
@@ -14,6 +14,9 @@
 
 package com.liferay.login.authentication.google.web.internal.portlet.action;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
@@ -37,6 +40,7 @@ import javax.portlet.PortletMode;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -87,14 +91,28 @@ public class GoogleLoginAction extends BaseStrutsAction {
 			if (Validator.isNotNull(authorizationCode)) {
 				String returnRequestUri = getReturnRequestUri(request);
 
-				User user = _googleAuthorization.addOrUpdateUser(
-					session, themeDisplay.getCompanyId(), authorizationCode,
-					returnRequestUri, _scopesLogin);
+				try {
+					User user = _googleAuthorization.addOrUpdateUser(
+						session, themeDisplay.getCompanyId(), authorizationCode,
+						returnRequestUri, _scopesLogin);
 
-				if ((user != null) &&
-					(user.getStatus() == WorkflowConstants.STATUS_INCOMPLETE)) {
+					if ((user != null) &&
+						(user.getStatus() ==
+							WorkflowConstants.STATUS_INCOMPLETE)) {
 
-					sendUpdateAccountRedirect(request, response, user);
+						sendUpdateAccountRedirect(request, response, user);
+
+						return null;
+					}
+				}
+				catch (PortalException pe) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(pe, pe);
+					}
+
+					Class<?> clazz = pe.getClass();
+
+					sendError(clazz.getSimpleName(), request, response);
 
 					return null;
 				}
@@ -119,6 +137,22 @@ public class GoogleLoginAction extends BaseStrutsAction {
 	protected String getReturnRequestUri(HttpServletRequest request) {
 		return _portal.getPortalURL(request) + _portal.getPathMain() +
 			_REDIRECT_URI;
+	}
+
+	protected void sendError(
+			String error, HttpServletRequest request,
+			HttpServletResponse response)
+		throws Exception {
+
+		PortletURL portletURL = PortletURLFactoryUtil.create(
+			request, PortletKeys.LOGIN, PortletRequest.RENDER_PHASE);
+
+		portletURL.setParameter("error", error);
+		portletURL.setParameter(
+			"mvcRenderCommandName", "/login/google_login_error");
+		portletURL.setWindowState(LiferayWindowState.POP_UP);
+
+		response.sendRedirect(portletURL.toString());
 	}
 
 	protected void sendLoginRedirect(
@@ -170,6 +204,9 @@ public class GoogleLoginAction extends BaseStrutsAction {
 
 	private static final String _REDIRECT_URI =
 		"/portal/google_login?cmd=token";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GoogleLoginAction.class);
 
 	private static final List<String> _scopesLogin = Arrays.asList(
 		"email", "profile");

--- a/modules/apps/login/login-authentication-google-web/src/main/java/com/liferay/login/authentication/google/web/internal/portlet/action/GoogleLoginErrorMVCRenderCommand.java
+++ b/modules/apps/login/login-authentication-google-web/src/main/java/com/liferay/login/authentication/google/web/internal/portlet/action/GoogleLoginErrorMVCRenderCommand.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.login.authentication.google.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.exception.UserEmailAddressException;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.security.sso.google.StrangersNotAllowedException;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Stian Sigvartsen
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + PortletKeys.FAST_LOGIN,
+		"javax.portlet.name=" + PortletKeys.LOGIN,
+		"mvc.command.name=/login/google_login_error"
+	},
+	service = MVCRenderCommand.class
+)
+public class GoogleLoginErrorMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		boolean googleAuthEnabled = PrefsPropsUtil.getBoolean(
+			themeDisplay.getCompanyId(), "google-auth-enabled", true);
+
+		if (!googleAuthEnabled) {
+			throw new PortletException(
+				new PrincipalException.MustBeEnabled(
+					themeDisplay.getCompanyId(),
+					GoogleLoginAction.class.getName()));
+		}
+
+		String error = ParamUtil.getString(renderRequest, "error");
+
+		if (ArrayUtil.contains(_ERRORS, error)) {
+			SessionErrors.add(renderRequest, error);
+		}
+		else {
+			SessionErrors.add(renderRequest, "unknownError");
+		}
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			renderRequest);
+
+		HttpServletResponse httpServletResponse =
+			_portal.getHttpServletResponse(renderResponse);
+
+		try {
+			RequestDispatcher requestDispatcher =
+				_servletContext.getRequestDispatcher("/error.jsp");
+
+			requestDispatcher.forward(httpServletRequest, httpServletResponse);
+		}
+		catch (Exception e) {
+			throw new PortletException("Unable to include error.jsp", e);
+		}
+
+		return MVCRenderConstants.MVC_PATH_VALUE_SKIP_DISPATCH;
+	}
+
+	private static final String[] _ERRORS = {
+		UserEmailAddressException.MustNotUseCompanyMx.class.getSimpleName(),
+		StrangersNotAllowedException.class.getSimpleName()
+	};
+
+	@Reference
+	private Portal _portal;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.login.authentication.google.web)"
+	)
+	private ServletContext _servletContext;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/login/login-authentication-google-web/src/main/resources/META-INF/resources/error.jsp
+++ b/modules/apps/login/login-authentication-google-web/src/main/resources/META-INF/resources/error.jsp
@@ -1,0 +1,31 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<div class="sheet">
+	<h2 class="sheet-title">
+		<liferay-ui:message key="failed-to-sign-in-using-this-google-account" />
+	</h2>
+
+	<liferay-ui:error key="MustNotUseCompanyMx" message="this-google-account-cannot-be-used-to-register-a-new-user-because-its-email-domain-is-reserved" />
+	<liferay-ui:error key="StrangersNotAllowedException" message="only-known-users-are-allowed-to-sign-in-using-google" />
+	<liferay-ui:error key="unknownError" message="there-was-an-unknown-error" />
+
+	<aui:button-row>
+		<aui:button onClick="window.close();" value="close" />
+	</aui:button-row>
+</div>

--- a/modules/apps/login/login-authentication-google-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/login/login-authentication-google-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,20 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<portlet:defineObjects />

--- a/modules/apps/login/login-authentication-google-web/src/main/resources/content/Language.properties
+++ b/modules/apps/login/login-authentication-google-web/src/main/resources/content/Language.properties
@@ -1,1 +1,5 @@
 google=Google
+failed-to-sign-in-using-this-google-account=Failed to sign in using this Google account
+only-known-users-are-allowed-to-sign-in-using-google=Only known users are allowed to sign in using Google.
+there-was-an-unknown-error=There was an unknown error.
+this-google-account-cannot-be-used-to-register-a-new-user-because-its-email-domain-is-reserved=This google account cannot be used to register a new user because its email domain is reserved.

--- a/modules/apps/portal-security-sso/portal-security-sso-google-api/src/main/java/com/liferay/portal/security/sso/google/StrangersNotAllowedException.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-google-api/src/main/java/com/liferay/portal/security/sso/google/StrangersNotAllowedException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.sso.google;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Stian Sigvartsen
+ */
+public class StrangersNotAllowedException extends PortalException {
+
+	public StrangersNotAllowedException(long companyId) {
+		super(String.format("Company %s does not allow strangers", companyId));
+
+		this.companyId = companyId;
+	}
+
+	public final long companyId;
+
+}

--- a/modules/apps/portal-security-sso/portal-security-sso-google-api/src/main/resources/com/liferay/portal/security/sso/google/packageinfo
+++ b/modules/apps/portal-security-sso/portal-security-sso-google-api/src/main/resources/com/liferay/portal/security/sso/google/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
I've integrated the approach you suggested for Facebook SSO ( https://github.com/stian-sigvartsen/liferay-portal/pull/123 ) which is to simply forward the error for display by URL parameter.