### PR TITLE
[TLS] LPS-83884 We need to fix LicenseUtil as well

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/LicenseUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/LicenseUtil.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.JavaDetector;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
@@ -84,7 +85,11 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -313,7 +318,14 @@ public class LicenseUtil {
 		HttpClient httpClient = null;
 
 		HttpClientConnectionManager httpClientConnectionManager =
-			new BasicHttpClientConnectionManager();
+			new BasicHttpClientConnectionManager(
+				RegistryBuilder.<ConnectionSocketFactory>create(
+				).register(
+					Http.HTTP, PlainConnectionSocketFactory.getSocketFactory()
+				).register(
+					Http.HTTPS,
+					SSLConnectionSocketFactory.getSystemSocketFactory()
+				).build());
 
 		try {
 			HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83884

Hi Tomas,

I chose `SSLConnectionSocketFactory.getSystemSocketFactory()`: based on its javadoc:
>Obtains default SSL socket factory with an SSL context based on system properties as described in Java™ Secure Socket Extension (JSSE) Reference Guide (http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html).

Means `https.protocols` and `https.cipherSuites` are considered.

The logic comes from 
`BasicHttpClientConnectionManager()`
which will use internally
`org.apache.http.impl.conn.BasicHttpClientConnectionManager.getDefaultRegistry()`:
```java
    private static Registry<ConnectionSocketFactory> getDefaultRegistry() {
        return RegistryBuilder.<ConnectionSocketFactory>create()
                .register("http", PlainConnectionSocketFactory.getSocketFactory())
                .register("https", SSLConnectionSocketFactory.getSocketFactory())
                .build();
    }
```

Regards,
Tibor