### PR TITLE
LPS-64815 - Avoid Company Key Extraction

### DIFF
--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
@@ -47,6 +47,13 @@ public interface FreeMarkerEngineConfiguration {
 	public String[] restrictedClasses();
 
 	@Meta.AD(
+		deflt = "com.liferay.portal.model.impl.CompanyImpl=key|juan.com.local=juan",
+		description = "enter-class-name-property-file-syntax",
+		name = "restricted-class-properties", required = false
+	)
+	public String[] restrictedClassProperties();
+
+	@Meta.AD(
 		deflt = "httpUtilUnsafe|objectUtil|serviceLocator|staticFieldGetter|staticUtil|utilLocator",
 		name = "restricted-variables", required = false
 	)

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerManager.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerManager.java
@@ -64,8 +64,10 @@ import java.lang.reflect.Method;
 
 import java.net.URL;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -277,6 +279,10 @@ public class FreeMarkerManager extends BaseSingleTemplateManager {
 			_freeMarkerEngineConfiguration.localizedLookup());
 		_configuration.setNewBuiltinClassResolver(_templateClassResolver);
 
+		Map<String, List<String>> restrictedClassPropertiesMap =
+			_getRestrictedClassPropertiesMap(
+				_freeMarkerEngineConfiguration.restrictedClassProperties());
+
 		_configuration.setObjectWrapper(
 			new LiferayObjectWrapper(
 				_freeMarkerEngineConfiguration.allowedClasses(),
@@ -433,6 +439,33 @@ public class FreeMarkerManager extends BaseSingleTemplateManager {
 	@Reference(unbind = "-")
 	protected void setSingleVMPool(SingleVMPool singleVMPool) {
 		_singleVMPool = singleVMPool;
+	}
+
+	private Map<String, List<String>> _getRestrictedClassPropertiesMap(
+		String[] restrictedClassProperties) {
+
+		Map<String, List<String>> restrictedClassPropertiesMap =
+			new HashMap<>();
+
+		for (String restrictedClassProperty : restrictedClassProperties) {
+			String className = StringUtil.extractFirst(
+				restrictedClassProperty.trim(), StringPool.EQUAL);
+			String propertyName = StringUtil.extractLast(
+				restrictedClassProperty.trim(), StringPool.EQUAL);
+
+			if (restrictedClassPropertiesMap.containsKey(className)) {
+				List<String> properties = restrictedClassPropertiesMap.get(
+					className);
+
+				properties.add(propertyName);
+			}
+			else {
+				restrictedClassPropertiesMap.put(
+					className.trim(), Arrays.asList(propertyName));
+			}
+		}
+
+		return restrictedClassPropertiesMap;
 	}
 
 	private static final Class<?>[] _INTERFACES = {ServletContext.class};

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerManager.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerManager.java
@@ -286,7 +286,8 @@ public class FreeMarkerManager extends BaseSingleTemplateManager {
 		_configuration.setObjectWrapper(
 			new LiferayObjectWrapper(
 				_freeMarkerEngineConfiguration.allowedClasses(),
-				_freeMarkerEngineConfiguration.restrictedClasses()));
+				_freeMarkerEngineConfiguration.restrictedClasses(),
+				restrictedClassPropertiesMap));
 
 		try {
 			_configuration.setSetting(

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/resources/content/Language.properties
@@ -1,8 +1,10 @@
 allowed-classes=Allowed Classes
+enter-class-name-property-file-syntax=Enter full class name and restricted property (properties file syntax, delimiter is equals "=")
 freemarker-engine-configuration-name=FreeMarker Engine
 localized-lookup=Localized Lookup
 macro-library=Macro Library
 resource-modification-check=Resource Modification Check
 restricted-classes=Restricted Classes
+restricted-class-properties=Restricted Property of Class
 restricted-variables=Restricted Variables
 template-exception-handler=Template Exception Handler


### PR DESCRIPTION
Fix this issue in a configurable way: https://issues.liferay.com/browse/LPS-64815

I've included a new FreeMarker Engine Configuration that allows to restrict properties of classes that are not accessible from the template. When the template is processed, using reflection checks if the restricted property is present and set it to null.

About the configuration syntax: a _line_ must be set for each property using a properties file syntax (example: `com.liferay.portal.model.impl.CompanyImpl=key|com.liferay.portal.other.Class=name|com.liferay.portal.other.Class=id`)
I've initially tried to do something like this: `com.liferay.portal.model.impl.CompanyImpl[key]|com.liferay.portal.other.Class[name,id]` and it worked for the backend processing (I mean, it recovers correctly an array with: `{"com.liferay.portal.model.impl.CompanyImpl[key]","com.liferay.portal.other.Class[name,id]"}`), but conversion to web configuration printed it incorrectly (looks like it's neccessary to escape ',' character, see screenshot attached):

<img width="500" alt="screenshot - freemarker configuration" src="https://user-images.githubusercontent.com/19305424/50520994-b1d5f380-0ac3-11e9-8cdc-f1b995412315.png">
