### PR TITLE
LPS-64815 - Extraction using Templates

### DIFF
--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
@@ -47,6 +47,13 @@ public interface FreeMarkerEngineConfiguration {
 	public String[] restrictedClasses();
 
 	@Meta.AD(
+		deflt = "com.liferay.portal.model.impl.CompanyImpl=key",
+		description = "enter-class-name-property-file-syntax",
+		name = "restricted-class-properties", required = false
+	)
+	public String[] restrictedClassProperties();
+
+	@Meta.AD(
 		deflt = "httpUtilUnsafe|objectUtil|serviceLocator|staticFieldGetter|staticUtil|utilLocator",
 		name = "restricted-variables", required = false
 	)

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/LiferayFreeMarkerBeanModel.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/LiferayFreeMarkerBeanModel.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.template.freemarker.internal;
+
+import com.liferay.petra.string.StringBundler;
+
+import freemarker.ext.beans.BeanModel;
+import freemarker.ext.beans.BeansWrapper;
+import freemarker.ext.beans.InvalidPropertyException;
+
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+import java.util.List;
+
+/**
+ * @author Marta Medio
+ */
+public class LiferayFreeMarkerBeanModel extends BeanModel {
+
+	public LiferayFreeMarkerBeanModel(Object object, BeansWrapper wrapper) {
+		super(object, wrapper);
+	}
+
+	@Override
+	public TemplateModel get(String key) throws TemplateModelException {
+		if (key.startsWith("get")) {
+			String property = key.substring(3);
+
+			property =
+				Character.toLowerCase(property.charAt(0)) +
+					property.substring(1);
+
+			if (_restrictedProperties.contains(property)) {
+				throw new InvalidPropertyException(
+					StringBundler.concat(
+						"Forbbiden access to property ", key, " of ",
+						object.getClass()));
+			}
+		}
+
+		return super.get(key);
+	}
+
+	public void setRestrictedProperties(List<String> restrictedProperties) {
+		_restrictedProperties = restrictedProperties;
+	}
+
+	private List<String> _restrictedProperties;
+
+}

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/resources/content/Language.properties
@@ -1,8 +1,10 @@
 allowed-classes=Allowed Classes
+enter-class-name-property-file-syntax=Enter full class name and restricted property (properties file syntax, delimiter is equals "=")
 freemarker-engine-configuration-name=FreeMarker Engine
 localized-lookup=Localized Lookup
 macro-library=Macro Library
 resource-modification-check=Resource Modification Check
 restricted-classes=Restricted Classes
+restricted-class-properties=Restricted Property of Class
 restricted-variables=Restricted Variables
 template-exception-handler=Template Exception Handler

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/LiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/LiferayObjectWrapperTest.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.template.freemarker.internal;
 
+import org.hamcrest.CoreMatchers;
+
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -44,6 +46,7 @@ import freemarker.template.Version;
 import java.lang.reflect.Field;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -75,27 +78,28 @@ public class LiferayObjectWrapperTest {
 	@Test
 	public void testCheckClassIsRestricted() {
 		_testCheckClassIsRestricted(
-			new LiferayObjectWrapper(null, null), TestLiferayObject.class,
+			new LiferayObjectWrapper(null, null, null), TestLiferayObject.class,
 			null);
 
 		_testCheckClassIsRestricted(
 			new LiferayObjectWrapper(
 				new String[] {TestLiferayObject.class.getName()},
-				new String[] {TestLiferayObject.class.getName()}),
-			TestLiferayObject.class, null);
-
-		_testCheckClassIsRestricted(
-			new LiferayObjectWrapper(null, new String[] {"java.lang.String"}),
+				new String[] {TestLiferayObject.class.getName()}, null),
 			TestLiferayObject.class, null);
 
 		_testCheckClassIsRestricted(
 			new LiferayObjectWrapper(
-				null, new String[] {"com.liferay.portal.cache"}),
+				null, new String[] {"java.lang.String"}, null),
 			TestLiferayObject.class, null);
 
 		_testCheckClassIsRestricted(
 			new LiferayObjectWrapper(
-				null, new String[] {TestLiferayObject.class.getName()}),
+				null, new String[] {"com.liferay.portal.cache"}, null),
+			TestLiferayObject.class, null);
+
+		_testCheckClassIsRestricted(
+			new LiferayObjectWrapper(
+				null, new String[] {TestLiferayObject.class.getName()}, null),
 			TestLiferayObject.class,
 			StringBundler.concat(
 				"Denied resolving class ", TestLiferayObject.class.getName(),
@@ -103,7 +107,8 @@ public class LiferayObjectWrapperTest {
 
 		_testCheckClassIsRestricted(
 			new LiferayObjectWrapper(
-				null, new String[] {"com.liferay.portal.template.freemarker"}),
+				null, new String[] {"com.liferay.portal.template.freemarker"},
+				null),
 			TestLiferayObject.class,
 			StringBundler.concat(
 				"Denied resolving class ", TestLiferayObject.class.getName(),
@@ -111,7 +116,8 @@ public class LiferayObjectWrapperTest {
 
 		_testCheckClassIsRestricted(
 			new LiferayObjectWrapper(
-				null, new String[] {"com.liferay.portal.template.freemarker"}),
+				null, new String[] {"com.liferay.portal.template.freemarker"},
+				null),
 			byte.class, null);
 	}
 
@@ -127,12 +133,29 @@ public class LiferayObjectWrapperTest {
 			_testCheckClassIsRestricted(
 				new LiferayObjectWrapper(
 					new String[] {TestLiferayObject.class.getName()},
-					new String[] {TestLiferayObject.class.getName()}),
+					new String[] {TestLiferayObject.class.getName()}, null),
 				TestLiferayObject.class, null);
 		}
 		finally {
 			thread.setContextClassLoader(contextClassLoader);
 		}
+	}
+
+	@Test
+	public void testCheckClassPropertyIsRestricted() throws Exception {
+		Map<String, List<String>> restrictedClassProperties = new HashMap<>();
+
+		restrictedClassProperties.put(
+			TestLiferayPropertyObject.class.getName(), Arrays.asList("name"));
+
+		LiferayObjectWrapper liferayObjectWrapper = new LiferayObjectWrapper(
+			null, null, restrictedClassProperties);
+
+		TemplateModel model = liferayObjectWrapper.wrap(
+			new TestLiferayPropertyObject("name"));
+
+		Assert.assertThat(
+			model, CoreMatchers.instanceOf(LiferayFreeMarkerBeanModel.class));
 	}
 
 	@Test
@@ -145,7 +168,7 @@ public class LiferayObjectWrapperTest {
 				Collections.singletonList("com.liferay.package.name"),
 				ReflectionTestUtil.getFieldValue(
 					new LiferayObjectWrapper(
-						null, new String[] {"com.liferay.package.name"}),
+						null, new String[] {"com.liferay.package.name"}, null),
 					"_restrictedPackageNames"));
 
 			List<LogRecord> logRecords = captureHandler.getLogRecords();
@@ -168,7 +191,7 @@ public class LiferayObjectWrapperTest {
 				Collections.singletonList("com.liferay.package.name"),
 				ReflectionTestUtil.getFieldValue(
 					new LiferayObjectWrapper(
-						null, new String[] {"com.liferay.package.name"}),
+						null, new String[] {"com.liferay.package.name"}, null),
 					"_restrictedPackageNames"));
 
 			List<LogRecord> logRecords = captureHandler.getLogRecords();
@@ -180,7 +203,7 @@ public class LiferayObjectWrapperTest {
 			LiferayObjectWrapper.class, "_cacheClassNamesField", null);
 
 		try {
-			new LiferayObjectWrapper(null, null);
+			new LiferayObjectWrapper(null, null, null);
 
 			Assert.fail("NullPointerException was not thrown");
 		}
@@ -197,7 +220,7 @@ public class LiferayObjectWrapperTest {
 	@Test
 	public void testHandleUnknownType() throws Exception {
 		LiferayObjectWrapper liferayObjectWrapper = new LiferayObjectWrapper(
-			null, null);
+			null, null, null);
 
 		// 1. Handle Enumeration
 
@@ -300,21 +323,39 @@ public class LiferayObjectWrapperTest {
 
 	@Test
 	public void testWrap() throws Exception {
-		_testWrap(new LiferayObjectWrapper(null, null));
+		_testWrap(new LiferayObjectWrapper(null, null, null));
 		_testWrap(
-			new LiferayObjectWrapper(new String[] {StringPool.STAR}, null));
+			new LiferayObjectWrapper(
+				new String[] {StringPool.STAR}, null, null));
 		_testWrap(
 			new LiferayObjectWrapper(
 				new String[] {StringPool.STAR},
-				new String[] {LiferayObjectWrapper.class.getName()}));
+				new String[] {LiferayObjectWrapper.class.getName()}, null));
 		_testWrap(
-			new LiferayObjectWrapper(new String[] {StringPool.BLANK}, null));
+			new LiferayObjectWrapper(
+				new String[] {StringPool.BLANK}, null, null));
 		_testWrap(
-			new LiferayObjectWrapper(null, new String[] {StringPool.BLANK}));
+			new LiferayObjectWrapper(
+				null, new String[] {StringPool.BLANK}, null));
 		_testWrap(
 			new LiferayObjectWrapper(
 				new String[] {StringPool.BLANK},
-				new String[] {StringPool.BLANK}));
+				new String[] {StringPool.BLANK}, null));
+
+		Map<String, List<String>> restrictedClassProperties = new HashMap<>();
+
+		_testWrap(
+			new LiferayObjectWrapper(
+				new String[] {StringPool.BLANK},
+				new String[] {StringPool.BLANK}, restrictedClassProperties));
+
+		restrictedClassProperties.put(
+			TestLiferayPropertyObject.class.getName(), Arrays.asList("name"));
+
+		_testWrap(
+			new LiferayObjectWrapper(
+				new String[] {StringPool.BLANK},
+				new String[] {StringPool.BLANK}, restrictedClassProperties));
 	}
 
 	private void _assertModelFactoryCache(
@@ -424,6 +465,14 @@ public class LiferayObjectWrapperTest {
 			dummyTemplateModel, liferayObjectWrapper.wrap(StringPool.BLANK));
 
 		modelFactories.clear();
+
+		// 8. Test
+
+		_assertTemplateModel(
+			"TestLiferayObject", stringModel -> stringModel.getAsString(),
+			StringModel.class.cast(
+				liferayObjectWrapper.wrap(
+					new TestLiferayObject("TestLiferayObject"))));
 	}
 
 	private class TestLiferayCollection extends ArrayList<String> {
@@ -458,6 +507,29 @@ public class LiferayObjectWrapperTest {
 		}
 
 		private final String _name;
+
+	}
+
+	private class TestLiferayPropertyObject {
+
+		public String getName() {
+			return _name;
+		}
+
+		public void setName(String name) {
+			_name = name;
+		}
+
+		@Override
+		public String toString() {
+			return _name;
+		}
+
+		private TestLiferayPropertyObject(String name) {
+			_name = name;
+		}
+
+		private String _name;
 
 	}
 

--- a/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/configuration/VelocityEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/configuration/VelocityEngineConfiguration.java
@@ -48,6 +48,13 @@ public interface VelocityEngineConfiguration {
 	public String[] restrictedClasses();
 
 	@Meta.AD(
+		deflt = "com.liferay.portal.model.impl.CompanyImpl=key",
+		description = "enter-class-name-property-file-syntax",
+		name = "restricted-class-properties", required = false
+	)
+	public String[] restrictedClassProperties();
+
+	@Meta.AD(
 		deflt = "java.lang.reflect", name = "restricted-packages",
 		required = false
 	)

--- a/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/internal/VelocityManager.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/internal/VelocityManager.java
@@ -143,6 +143,11 @@ public class VelocityManager extends BaseSingleTemplateManager {
 					_velocityEngineConfiguration.restrictedClasses()));
 
 			extendedProperties.setProperty(
+				"liferay." + RuntimeConstants.INTROSPECTOR_RESTRICT_CLASSES +
+					".properties",
+				_velocityEngineConfiguration.restrictedClassProperties());
+
+			extendedProperties.setProperty(
 				RuntimeConstants.INTROSPECTOR_RESTRICT_PACKAGES,
 				StringUtil.merge(
 					_velocityEngineConfiguration.restrictedPackages()));

--- a/modules/apps/portal-template/portal-template-velocity/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-template/portal-template-velocity/src/main/resources/content/Language.properties
@@ -1,9 +1,11 @@
 directive-if-to-string-null-check=Directive If to String Null Check
+enter-class-name-property-file-syntax=Enter full class name and restricted property (properties file syntax, delimiter is equals "=")
 logger=Logger
 logger-category=Logger Category
 resource-modification-check-interval=Resource Modification Check Interval
 restricted-classes=Restricted Classes
 restricted-packages=Restricted Packages
+restricted-class-properties=Restricted Property of Class
 restricted-variables=Restricted Variables
 velocity-engine-configuration-name=Velocity Engine
 velocity-macro-library=Velocity Macro Library

--- a/modules/apps/portal-template/portal-template-velocity/src/test/java/com/liferay/portal/template/velocity/internal/VelocityTemplateTest.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/test/java/com/liferay/portal/template/velocity/internal/VelocityTemplateTest.java
@@ -132,6 +132,10 @@ public class VelocityTemplateTest {
 			RuntimeConstants.INTROSPECTOR_RESTRICT_CLASSES,
 			StringUtil.merge(velocityEngineConfiguration.restrictedClasses()));
 		extendedProperties.setProperty(
+			"liferay." + RuntimeConstants.INTROSPECTOR_RESTRICT_CLASSES +
+				".properties",
+			velocityEngineConfiguration.restrictedClassProperties());
+		extendedProperties.setProperty(
 			RuntimeConstants.INTROSPECTOR_RESTRICT_PACKAGES,
 			StringUtil.merge(velocityEngineConfiguration.restrictedPackages()));
 		extendedProperties.setProperty(


### PR DESCRIPTION
_FreeMarker solution:_ Like you suggested, I wrap in an object the BeanModel used by the library. According to the official documentation, there is no way to return empty string without using reflection to change the original object (CompanyImpl), so I have raised an exception when the template tries to print a restricted property.

_Velocity solution:_ I have followed the same process that already exists for class restriction

About the configuration syntax, see previous PR: https://github.com/topolik/liferay-portal/pull/673