### PR TITLE
OAUTH2-271 Apply URL encoding to ":" character

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/authorize/AuthorizationCodeGrantServiceContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/authorize/AuthorizationCodeGrantServiceContainerRequestFilter.java
@@ -160,6 +160,13 @@ public class AuthorizationCodeGrantServiceContainerRequestFilter
 			requestURIString = requestURIString.substring(portalURL.length());
 		}
 
+		// Workaround LPS-94559
+
+		String rawQuery = requestURI.getRawQuery();
+
+		requestURIString = requestURIString.replaceAll(
+			"\\?.*", "?" + rawQuery.replaceAll(":", "%3A"));
+
 		loginURL = _http.addParameter(loginURL, "redirect", requestURIString);
 
 		containerRequestContext.abortWith(


### PR DESCRIPTION
Hi Tomas. This is the fix we discussed.

@victorg1991 has tested that it works with a native client.