### PR TITLE
[TECHNICAL SUPPORT] LPS-95871 LDAP groups are not getting imported if the user has a comma in its name

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -966,9 +966,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 			String fullUserDN = binding.getNameInNamespace();
 
-			sb.append(
-				_portalLDAP.encodeFilterAttribute(
-					escapeLDAPName(fullUserDN), false));
+			sb.append(_portalLDAP.encodeFilterAttribute(fullUserDN, false));
 
 			sb.append(StringPool.CLOSE_PARENTHESIS);
 			sb.append(StringPool.CLOSE_PARENTHESIS);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-95871