### PR TITLE
[TECHNICAL SUPPORT]LPS-97902 JSONWS type conversion error for custom endpoint

### DIFF
--- a/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionImpl.java
+++ b/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionImpl.java
@@ -209,6 +209,13 @@ public class JSONWebServiceActionImpl implements JSONWebServiceAction {
 							targetType = classLoader.loadClass(modelClassName);
 						}
 						catch (ClassNotFoundException cnfe) {
+							Class<?> actionClass =
+								_jsonWebServiceActionConfig.getActionClass();
+							ClassLoader actionClassloader =
+								actionClass.getClassLoader();
+
+							targetType =
+								actionClassloader.loadClass(modelClassName);
 						}
 					}
 


### PR DESCRIPTION
Hi,

Remote service calls doesn't work for module services as at JSON deserialization we try to use the portals context classloader to load the parameter class in case of interfaces.

I didn't have a better idea than to fallback to the action class' classloader as otherwise I don't see any way to determine which classloader should be used (or how to get that classloader). But any ideas are welcome :)

Reproduction steps and a PoC service are on the LPS.
https://issues.liferay.com/browse/LPS-97902 

Br,
Norbert