### PR TITLE
LPS-102777 Secure test LDAP connection command

### DIFF
--- a/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/java/com/liferay/portal/settings/authentication/ldap/web/internal/portlet/action/PortalSettingsTestLDAPConnectionMVCRenderCommand.java
+++ b/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/java/com/liferay/portal/settings/authentication/ldap/web/internal/portlet/action/PortalSettingsTestLDAPConnectionMVCRenderCommand.java
@@ -16,6 +16,13 @@ package com.liferay.portal.settings.authentication.ldap.web.internal.portlet.act
 
 import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import javax.servlet.ServletContext;
 
@@ -36,6 +43,25 @@ public class PortalSettingsTestLDAPConnectionMVCRenderCommand
 	extends BasePortalSettingsMVCRenderCommand {
 
 	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		try {
+			AuthTokenUtil.checkCSRFToken(
+				_portal.getOriginalServletRequest(
+					_portal.getHttpServletRequest(renderRequest)),
+				PortalSettingsTestLDAPConnectionMVCRenderCommand.class.
+					getName());
+		}
+		catch (PrincipalException pe) {
+			throw new PortletException(pe);
+		}
+
+		return super.render(renderRequest, renderResponse);
+	}
+
+	@Override
 	protected String getJspPath() {
 		return _JSP_PATH;
 	}
@@ -50,5 +76,8 @@ public class PortalSettingsTestLDAPConnectionMVCRenderCommand
 
 	private static final String _JSP_PATH =
 		"/com.liferay.portal.settings.web/test_ldap_connection.jsp";
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/edit_ldap_server.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/edit_ldap_server.jsp
@@ -484,6 +484,8 @@ renderResponse.setTitle((ldapServerId == 0) ? LanguageUtil.get(resourceBundle, "
 
 			if (type === 'ldapConnection') {
 				url = '<portlet:renderURL copyCurrentRenderParameters="<%= false %>" windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_ldap_connection" /></portlet:renderURL>';
+
+				data.p_auth = '<%= AuthTokenUtil.getToken(request) %>';
 			}
 			else if (type === 'ldapGroups') {
 				url = '<portlet:renderURL copyCurrentRenderParameters="<%= false %>" windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_ldap_groups" /></portlet:renderURL>';

--- a/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -28,6 +28,7 @@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+page import="com.liferay.portal.kernel.security.auth.AuthTokenUtil" %><%@
 page import="com.liferay.portal.kernel.security.auth.FullNameDefinition" %><%@
 page import="com.liferay.portal.kernel.security.auth.FullNameDefinitionFactory" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@


### PR DESCRIPTION
Hi Tomas. I wasn't sure if it is acceptable to protect MVCRenderCommands like this. There are no other occurrences of this in the codebase. There are examples of Struts Actions and serveResource() examples of doing this. 

Converting it to Struts seemed over engineering the fix. Converting to serveResouce() seems slight more appropriate, but adds complexity because we're only interested in a text/html response. Additionally if we did convert then we should also convert the other test commands.

/cc @csierra @lipuz