### PR TITLE
OAUTH2-286 Why not remove tracking of bundle?

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -64,6 +65,17 @@ public interface OAuth2ApplicationLocalService
 	 *
 	 * Never modify or reference this interface directly. Always use {@link OAuth2ApplicationLocalServiceUtil} to access the o auth2 application local service. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2ApplicationLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
+	public OAuth2Application addOAuth2Application(
+			long companyId, long userId, String userName,
+			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,
+			String clientId, int clientProfile, String clientSecret,
+			String description, List<String> featuresList, String homePageURL,
+			long iconFileEntryId, String name, String privacyPolicyURL,
+			List<String> redirectURIsList,
+			Consumer<OAuth2Scope.Builder> builderConsumer,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public OAuth2Application addOAuth2Application(
 			long companyId, long userId, String userName,
 			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -53,6 +53,29 @@ public class OAuth2ApplicationLocalServiceUtil {
 				java.util.List<String> featuresList, String homePageURL,
 				long iconFileEntryId, String name, String privacyPolicyURL,
 				java.util.List<String> redirectURIsList,
+				java.util.function.Consumer<OAuth2Scope.Builder>
+					builderConsumer,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addOAuth2Application(
+			companyId, userId, userName, allowedGrantTypesList,
+			clientCredentialUserId, clientId, clientProfile, clientSecret,
+			description, featuresList, homePageURL, iconFileEntryId, name,
+			privacyPolicyURL, redirectURIsList, builderConsumer,
+			serviceContext);
+	}
+
+	public static com.liferay.oauth2.provider.model.OAuth2Application
+			addOAuth2Application(
+				long companyId, long userId, String userName,
+				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
+					allowedGrantTypesList,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String name, String privacyPolicyURL,
+				java.util.List<String> redirectURIsList,
 				java.util.List<String> scopeAliasesList,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -49,6 +49,30 @@ public class OAuth2ApplicationLocalServiceWrapper
 				java.util.List<String> featuresList, String homePageURL,
 				long iconFileEntryId, String name, String privacyPolicyURL,
 				java.util.List<String> redirectURIsList,
+				java.util.function.Consumer<OAuth2Scope.Builder>
+					builderConsumer,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationLocalService.addOAuth2Application(
+			companyId, userId, userName, allowedGrantTypesList,
+			clientCredentialUserId, clientId, clientProfile, clientSecret,
+			description, featuresList, homePageURL, iconFileEntryId, name,
+			privacyPolicyURL, redirectURIsList, builderConsumer,
+			serviceContext);
+	}
+
+	@Override
+	public com.liferay.oauth2.provider.model.OAuth2Application
+			addOAuth2Application(
+				long companyId, long userId, String userName,
+				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
+					allowedGrantTypesList,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String name, String privacyPolicyURL,
+				java.util.List<String> redirectURIsList,
 				java.util.List<String> scopeAliasesList,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -60,6 +61,12 @@ public interface OAuth2ApplicationScopeAliasesLocalService
 	 *
 	 * Never modify or reference this interface directly. Always use {@link OAuth2ApplicationScopeAliasesLocalServiceUtil} to access the o auth2 application scope aliases local service. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2ApplicationScopeAliasesLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
+	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
+			long companyId, long userId, String userName,
+			long oAuth2ApplicationId,
+			Consumer<OAuth2Scope.Builder> builderConsumer)
+		throws PortalException;
+
 	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
 			long companyId, long userId, String userName,
 			long oAuth2ApplicationId, List<String> scopeAliasesList)

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
@@ -48,6 +48,19 @@ public class OAuth2ApplicationScopeAliasesLocalServiceUtil {
 				addOAuth2ApplicationScopeAliases(
 					long companyId, long userId, String userName,
 					long oAuth2ApplicationId,
+					java.util.function.Consumer<OAuth2Scope.Builder>
+						builderConsumer)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addOAuth2ApplicationScopeAliases(
+			companyId, userId, userName, oAuth2ApplicationId, builderConsumer);
+	}
+
+	public static
+		com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases
+				addOAuth2ApplicationScopeAliases(
+					long companyId, long userId, String userName,
+					long oAuth2ApplicationId,
 					java.util.List<String> scopeAliasesList)
 			throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
@@ -45,6 +45,21 @@ public class OAuth2ApplicationScopeAliasesLocalServiceWrapper
 			addOAuth2ApplicationScopeAliases(
 				long companyId, long userId, String userName,
 				long oAuth2ApplicationId,
+				java.util.function.Consumer<OAuth2Scope.Builder>
+					builderConsumer)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationScopeAliasesLocalService.
+			addOAuth2ApplicationScopeAliases(
+				companyId, userId, userName, oAuth2ApplicationId,
+				builderConsumer);
+	}
+
+	@Override
+	public com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases
+			addOAuth2ApplicationScopeAliases(
+				long companyId, long userId, String userName,
+				long oAuth2ApplicationId,
 				java.util.List<String> scopeAliasesList)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.service;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/**
+ * @author Stian Sigvartsen
+ * @author Carlos Sierra
+ */
+public interface OAuth2Scope {
+
+	public interface Builder {
+
+		public void forApplication(
+			String applicationName,
+			Consumer<ApplicationScopeAssigner>
+				applicationScopeAssignerConsumer);
+
+		public interface ApplicationScope {
+
+			public void mapToScopeAlias(Collection<String> scopeAliases);
+
+			public default void mapToScopeAlias(String... scopeAlias) {
+				mapToScopeAlias(Arrays.asList(scopeAlias));
+			}
+
+		}
+
+		public interface ApplicationScopeAssigner {
+
+			public ApplicationScope assignScope(Collection<String> scopes);
+
+			public default ApplicationScope assignScope(String... scope) {
+				return assignScope(Arrays.asList(scope));
+			}
+
+		}
+
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ScopeGrantLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ScopeGrantLocalService.java
@@ -99,13 +99,12 @@ public interface OAuth2ScopeGrantLocalService
 
 	public OAuth2ScopeGrant createOAuth2ScopeGrant(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope)
+			String applicationName, String scope, List<String> scopeAliases)
 		throws DuplicateOAuth2ScopeGrantException;
 
 	public OAuth2ScopeGrant createOAuth2ScopeGrant(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope,
-			List<String> scopeAliases)
+			String applicationName, String bundleSymbolicName, String scope)
 		throws DuplicateOAuth2ScopeGrantException;
 
 	public void deleteOAuth2AuthorizationOAuth2ScopeGrant(
@@ -286,8 +285,7 @@ public interface OAuth2ScopeGrantLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Collection<OAuth2ScopeGrant> getOAuth2ScopeGrants(
-		long companyId, String applicationName, String bundleSymbolicName,
-		String accessTokenContent);
+		long companyId, String applicationName, String accessTokenContent);
 
 	/**
 	 * Returns the number of o auth2 scope grants.

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ScopeGrantLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ScopeGrantLocalServiceUtil.java
@@ -110,6 +110,19 @@ public class OAuth2ScopeGrantLocalServiceUtil {
 	public static com.liferay.oauth2.provider.model.OAuth2ScopeGrant
 			createOAuth2ScopeGrant(
 				long companyId, long oAuth2ApplicationScopeAliasesId,
+				String applicationName, String scope,
+				java.util.List<String> scopeAliases)
+		throws com.liferay.oauth2.provider.exception.
+			DuplicateOAuth2ScopeGrantException {
+
+		return getService().createOAuth2ScopeGrant(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope,
+			scopeAliases);
+	}
+
+	public static com.liferay.oauth2.provider.model.OAuth2ScopeGrant
+			createOAuth2ScopeGrant(
+				long companyId, long oAuth2ApplicationScopeAliasesId,
 				String applicationName, String bundleSymbolicName, String scope)
 		throws com.liferay.oauth2.provider.exception.
 			DuplicateOAuth2ScopeGrantException {
@@ -117,19 +130,6 @@ public class OAuth2ScopeGrantLocalServiceUtil {
 		return getService().createOAuth2ScopeGrant(
 			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
 			bundleSymbolicName, scope);
-	}
-
-	public static com.liferay.oauth2.provider.model.OAuth2ScopeGrant
-			createOAuth2ScopeGrant(
-				long companyId, long oAuth2ApplicationScopeAliasesId,
-				String applicationName, String bundleSymbolicName, String scope,
-				java.util.List<String> scopeAliases)
-		throws com.liferay.oauth2.provider.exception.
-			DuplicateOAuth2ScopeGrantException {
-
-		return getService().createOAuth2ScopeGrant(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope, scopeAliases);
 	}
 
 	public static void deleteOAuth2AuthorizationOAuth2ScopeGrant(
@@ -416,10 +416,10 @@ public class OAuth2ScopeGrantLocalServiceUtil {
 		<com.liferay.oauth2.provider.model.OAuth2ScopeGrant>
 			getOAuth2ScopeGrants(
 				long companyId, String applicationName,
-				String bundleSymbolicName, String accessTokenContent) {
+				String accessTokenContent) {
 
 		return getService().getOAuth2ScopeGrants(
-			companyId, applicationName, bundleSymbolicName, accessTokenContent);
+			companyId, applicationName, accessTokenContent);
 	}
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ScopeGrantLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ScopeGrantLocalServiceWrapper.java
@@ -115,6 +115,20 @@ public class OAuth2ScopeGrantLocalServiceWrapper
 	public com.liferay.oauth2.provider.model.OAuth2ScopeGrant
 			createOAuth2ScopeGrant(
 				long companyId, long oAuth2ApplicationScopeAliasesId,
+				String applicationName, String scope,
+				java.util.List<String> scopeAliases)
+		throws com.liferay.oauth2.provider.exception.
+			DuplicateOAuth2ScopeGrantException {
+
+		return _oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope,
+			scopeAliases);
+	}
+
+	@Override
+	public com.liferay.oauth2.provider.model.OAuth2ScopeGrant
+			createOAuth2ScopeGrant(
+				long companyId, long oAuth2ApplicationScopeAliasesId,
 				String applicationName, String bundleSymbolicName, String scope)
 		throws com.liferay.oauth2.provider.exception.
 			DuplicateOAuth2ScopeGrantException {
@@ -122,20 +136,6 @@ public class OAuth2ScopeGrantLocalServiceWrapper
 		return _oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
 			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
 			bundleSymbolicName, scope);
-	}
-
-	@Override
-	public com.liferay.oauth2.provider.model.OAuth2ScopeGrant
-			createOAuth2ScopeGrant(
-				long companyId, long oAuth2ApplicationScopeAliasesId,
-				String applicationName, String bundleSymbolicName, String scope,
-				java.util.List<String> scopeAliases)
-		throws com.liferay.oauth2.provider.exception.
-			DuplicateOAuth2ScopeGrantException {
-
-		return _oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope, scopeAliases);
 	}
 
 	@Override
@@ -449,10 +449,10 @@ public class OAuth2ScopeGrantLocalServiceWrapper
 		<com.liferay.oauth2.provider.model.OAuth2ScopeGrant>
 			getOAuth2ScopeGrants(
 				long companyId, String applicationName,
-				String bundleSymbolicName, String accessTokenContent) {
+				String accessTokenContent) {
 
 		return _oAuth2ScopeGrantLocalService.getOAuth2ScopeGrants(
-			companyId, applicationName, bundleSymbolicName, accessTokenContent);
+			companyId, applicationName, accessTokenContent);
 	}
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ScopeGrantFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ScopeGrantFinder.java
@@ -24,8 +24,7 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface OAuth2ScopeGrantFinder {
 
 	public java.util.Collection
-		<com.liferay.oauth2.provider.model.OAuth2ScopeGrant> findByC_A_B_A(
-			long companyId, String applicationName, String bundleSymbolicName,
-			String accessTokenContent);
+		<com.liferay.oauth2.provider.model.OAuth2ScopeGrant> findByC_A_A(
+			long companyId, String applicationName, String accessTokenContent);
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ScopeGrantPersistence.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ScopeGrantPersistence.java
@@ -192,79 +192,73 @@ public interface OAuth2ScopeGrantPersistence
 		long oAuth2ApplicationScopeAliasesId);
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or throws a <code>NoSuchOAuth2ScopeGrantException</code> if it could not be found.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or throws a <code>NoSuchOAuth2ScopeGrantException</code> if it could not be found.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the matching o auth2 scope grant
 	 * @throws NoSuchOAuth2ScopeGrantException if a matching o auth2 scope grant could not be found
 	 */
-	public OAuth2ScopeGrant findByC_O_A_B_S(
+	public OAuth2ScopeGrant findByC_O_A_S(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope)
+			String applicationName, String scope)
 		throws NoSuchOAuth2ScopeGrantException;
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the matching o auth2 scope grant, or <code>null</code> if a matching o auth2 scope grant could not be found
 	 */
-	public OAuth2ScopeGrant fetchByC_O_A_B_S(
+	public OAuth2ScopeGrant fetchByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope);
+		String applicationName, String scope);
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching o auth2 scope grant, or <code>null</code> if a matching o auth2 scope grant could not be found
 	 */
-	public OAuth2ScopeGrant fetchByC_O_A_B_S(
+	public OAuth2ScopeGrant fetchByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope,
-		boolean useFinderCache);
+		String applicationName, String scope, boolean useFinderCache);
 
 	/**
-	 * Removes the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; from the database.
+	 * Removes the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; from the database.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the o auth2 scope grant that was removed
 	 */
-	public OAuth2ScopeGrant removeByC_O_A_B_S(
+	public OAuth2ScopeGrant removeByC_O_A_S(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope)
+			String applicationName, String scope)
 		throws NoSuchOAuth2ScopeGrantException;
 
 	/**
-	 * Returns the number of o auth2 scope grants where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63;.
+	 * Returns the number of o auth2 scope grants where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63;.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the number of matching o auth2 scope grants
 	 */
-	public int countByC_O_A_B_S(
+	public int countByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope);
+		String applicationName, String scope);
 
 	/**
 	 * Caches the o auth2 scope grant in the entity cache if it is enabled.

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ScopeGrantUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ScopeGrantUtil.java
@@ -314,105 +314,95 @@ public class OAuth2ScopeGrantUtil {
 	}
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or throws a <code>NoSuchOAuth2ScopeGrantException</code> if it could not be found.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or throws a <code>NoSuchOAuth2ScopeGrantException</code> if it could not be found.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the matching o auth2 scope grant
 	 * @throws NoSuchOAuth2ScopeGrantException if a matching o auth2 scope grant could not be found
 	 */
-	public static OAuth2ScopeGrant findByC_O_A_B_S(
+	public static OAuth2ScopeGrant findByC_O_A_S(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope)
+			String applicationName, String scope)
 		throws com.liferay.oauth2.provider.exception.
 			NoSuchOAuth2ScopeGrantException {
 
-		return getPersistence().findByC_O_A_B_S(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope);
+		return getPersistence().findByC_O_A_S(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope);
 	}
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the matching o auth2 scope grant, or <code>null</code> if a matching o auth2 scope grant could not be found
 	 */
-	public static OAuth2ScopeGrant fetchByC_O_A_B_S(
+	public static OAuth2ScopeGrant fetchByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope) {
+		String applicationName, String scope) {
 
-		return getPersistence().fetchByC_O_A_B_S(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope);
+		return getPersistence().fetchByC_O_A_S(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope);
 	}
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching o auth2 scope grant, or <code>null</code> if a matching o auth2 scope grant could not be found
 	 */
-	public static OAuth2ScopeGrant fetchByC_O_A_B_S(
+	public static OAuth2ScopeGrant fetchByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope,
-		boolean useFinderCache) {
+		String applicationName, String scope, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_O_A_B_S(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope, useFinderCache);
+		return getPersistence().fetchByC_O_A_S(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope,
+			useFinderCache);
 	}
 
 	/**
-	 * Removes the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; from the database.
+	 * Removes the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; from the database.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the o auth2 scope grant that was removed
 	 */
-	public static OAuth2ScopeGrant removeByC_O_A_B_S(
+	public static OAuth2ScopeGrant removeByC_O_A_S(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope)
+			String applicationName, String scope)
 		throws com.liferay.oauth2.provider.exception.
 			NoSuchOAuth2ScopeGrantException {
 
-		return getPersistence().removeByC_O_A_B_S(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope);
+		return getPersistence().removeByC_O_A_S(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope);
 	}
 
 	/**
-	 * Returns the number of o auth2 scope grants where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63;.
+	 * Returns the number of o auth2 scope grants where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63;.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the number of matching o auth2 scope grants
 	 */
-	public static int countByC_O_A_B_S(
+	public static int countByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope) {
+		String applicationName, String scope) {
 
-		return getPersistence().countByC_O_A_B_S(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope);
+		return getPersistence().countByC_O_A_S(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope);
 	}
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.2
+version 1.4.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/persistence/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.2
+version 3.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/ThreadLocalScopeContextScopeChecker.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/ThreadLocalScopeContextScopeChecker.java
@@ -49,7 +49,6 @@ public class ThreadLocalScopeContextScopeChecker
 		Collection<OAuth2ScopeGrant> oAuth2ScopeGrants = new ArrayList<>(
 			_oAuth2ScopeGrantLocalService.getOAuth2ScopeGrants(
 				_companyIdThreadLocal.get(), _applicationNameThreadLocal.get(),
-				_bundleSymbolicNameThreadLocal.get(),
 				_accessTokenThreadLocal.get()));
 
 		if (scopes.length > oAuth2ScopeGrants.size()) {
@@ -80,7 +79,6 @@ public class ThreadLocalScopeContextScopeChecker
 		Collection<OAuth2ScopeGrant> oAuth2ScopeGrants =
 			_oAuth2ScopeGrantLocalService.getOAuth2ScopeGrants(
 				_companyIdThreadLocal.get(), _applicationNameThreadLocal.get(),
-				_bundleSymbolicNameThreadLocal.get(),
 				_accessTokenThreadLocal.get());
 
 		for (String scope : scopes) {
@@ -109,7 +107,6 @@ public class ThreadLocalScopeContextScopeChecker
 		Collection<OAuth2ScopeGrant> oAuth2ScopeGrants =
 			_oAuth2ScopeGrantLocalService.getOAuth2ScopeGrants(
 				_companyIdThreadLocal.get(), _applicationNameThreadLocal.get(),
-				_bundleSymbolicNameThreadLocal.get(),
 				_accessTokenThreadLocal.get());
 
 		for (OAuth2ScopeGrant oAuth2ScopeGrant : oAuth2ScopeGrants) {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/LiferayOAuth2ScopeImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/LiferayOAuth2ScopeImpl.java
@@ -18,18 +18,13 @@ import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
 
 import java.util.Objects;
 
-import org.osgi.framework.Bundle;
-
 /**
  * @author Carlos Sierra Andrés
  */
 public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 
-	public LiferayOAuth2ScopeImpl(
-		String applicationName, Bundle bundle, String scope) {
-
+	public LiferayOAuth2ScopeImpl(String applicationName, String scope) {
 		_applicationName = applicationName;
-		_bundle = bundle;
 		_scope = scope;
 	}
 
@@ -48,7 +43,6 @@ public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 
 		if (Objects.equals(
 				_applicationName, liferayOAuth2ScopeImpl._applicationName) &&
-			Objects.equals(_bundle, liferayOAuth2ScopeImpl._bundle) &&
 			Objects.equals(_scope, liferayOAuth2ScopeImpl._scope)) {
 
 			return true;
@@ -63,18 +57,13 @@ public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 	}
 
 	@Override
-	public Bundle getBundle() {
-		return _bundle;
-	}
-
-	@Override
 	public String getScope() {
 		return _scope;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(_applicationName, _bundle, _scope);
+		return Objects.hash(_applicationName, _scope);
 	}
 
 	@Override
@@ -83,7 +72,6 @@ public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 	}
 
 	private final String _applicationName;
-	private final Bundle _bundle;
 	private final String _scope;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/LiferayOAuth2ScopeImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/LiferayOAuth2ScopeImpl.java
@@ -17,14 +17,20 @@ package com.liferay.oauth2.provider.scope.internal.liferay;
 import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
 
 import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.osgi.framework.Bundle;
 
 /**
  * @author Carlos Sierra Andrés
  */
 public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 
-	public LiferayOAuth2ScopeImpl(String applicationName, String scope) {
+	public LiferayOAuth2ScopeImpl(
+		String applicationName, Supplier<Bundle> bundleSupplier, String scope) {
+
 		_applicationName = applicationName;
+		_bundleSupplier = bundleSupplier;
 		_scope = scope;
 	}
 
@@ -57,6 +63,11 @@ public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 	}
 
 	@Override
+	public Bundle getBundle() {
+		return _bundleSupplier.get();
+	}
+
+	@Override
 	public String getScope() {
 		return _scope;
 	}
@@ -72,6 +83,7 @@ public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 	}
 
 	private final String _applicationName;
+	private final Supplier<Bundle> _bundleSupplier;
 	private final String _scope;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImpl.java
@@ -30,6 +30,7 @@ import com.liferay.osgi.service.tracker.collections.ServiceReferenceServiceTuple
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,7 +41,9 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Supplier;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
@@ -62,15 +65,8 @@ public class ScopeLocatorImpl implements ScopeLocator {
 	public LiferayOAuth2Scope getLiferayOAuth2Scope(
 		long companyId, String applicationName, String scope) {
 
-		ServiceReferenceServiceTuple<?, ScopeFinder>
-			serviceReferenceServiceTuple =
-				_scopeFinderByNameServiceTrackerMap.getService(applicationName);
-
-		if (serviceReferenceServiceTuple == null) {
-			return null;
-		}
-
-		return new LiferayOAuth2ScopeImpl(applicationName, scope);
+		return new LiferayOAuth2ScopeImpl(
+			applicationName, getBundleSupplier(applicationName), scope);
 	}
 
 	@Override
@@ -92,7 +88,9 @@ public class ScopeLocatorImpl implements ScopeLocator {
 			}
 
 			for (String scope : scopeFinder.findScopes()) {
-				liferayOAuth2Scopes.add(new LiferayOAuth2ScopeImpl(key, scope));
+				liferayOAuth2Scopes.add(
+					new LiferayOAuth2ScopeImpl(
+						key, getBundleSupplier(key), scope));
 			}
 		}
 
@@ -185,7 +183,9 @@ public class ScopeLocatorImpl implements ScopeLocator {
 			processedScopes.add(scope);
 
 			locatedScopes.add(
-				new LiferayOAuth2ScopeImpl(applicationName, scope));
+				new LiferayOAuth2ScopeImpl(
+					applicationName, getBundleSupplier(applicationName),
+					scope));
 
 			if (!scopeLocatorConfiguration.
 					includeScopesImpliedBeforeScopeMapping()) {
@@ -353,6 +353,43 @@ public class ScopeLocatorImpl implements ScopeLocator {
 		_scopeLocatorConfigurationProvidersScopedServiceTrackerMap.close();
 		_scopeMappersScopedServiceTrackerMap.close();
 		_scopeMatcherFactoriesServiceTrackerMap.close();
+	}
+
+	protected Supplier<Bundle> getBundleSupplier(String applicationName) {
+		return () -> {
+			ServiceReferenceServiceTuple<?, ScopeFinder>
+				serviceReferenceServiceTuple =
+					_scopeFinderByNameServiceTrackerMap.getService(
+						applicationName);
+
+			if (serviceReferenceServiceTuple == null) {
+				return null;
+			}
+
+			ServiceReference<?> serviceReference =
+				serviceReferenceServiceTuple.getServiceReference();
+
+			Object property = serviceReference.getProperty(
+				"original.service.bundleid");
+
+			if (property == null) {
+				return serviceReference.getBundle();
+			}
+
+			long bundleId = GetterUtil.getLong(property, -1L);
+
+			if (bundleId == -1) {
+				return serviceReference.getBundle();
+			}
+
+			Bundle bundle = _bundleContext.getBundle(bundleId);
+
+			if (bundle == null) {
+				return serviceReference.getBundle();
+			}
+
+			return bundle;
+		};
 	}
 
 	protected ScopeMatcherFactory getScopeMatcherFactory(long companyId) {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImpl.java
@@ -30,7 +30,6 @@ import com.liferay.osgi.service.tracker.collections.ServiceReferenceServiceTuple
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,7 +41,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
@@ -72,10 +70,7 @@ public class ScopeLocatorImpl implements ScopeLocator {
 			return null;
 		}
 
-		Bundle bundle = getBundle(
-			serviceReferenceServiceTuple.getServiceReference());
-
-		return new LiferayOAuth2ScopeImpl(applicationName, bundle, scope);
+		return new LiferayOAuth2ScopeImpl(applicationName, scope);
 	}
 
 	@Override
@@ -96,12 +91,8 @@ public class ScopeLocatorImpl implements ScopeLocator {
 				scopeFinder = serviceReferenceServiceTuple.getService();
 			}
 
-			Bundle bundle = getBundle(
-				serviceReferenceServiceTuple.getServiceReference());
-
 			for (String scope : scopeFinder.findScopes()) {
-				liferayOAuth2Scopes.add(
-					new LiferayOAuth2ScopeImpl(key, bundle, scope));
+				liferayOAuth2Scopes.add(new LiferayOAuth2ScopeImpl(key, scope));
 			}
 		}
 
@@ -149,8 +140,6 @@ public class ScopeLocatorImpl implements ScopeLocator {
 		ServiceReference<?> serviceReference =
 			serviceReferenceServiceTuple.getServiceReference();
 
-		Bundle bundle = getBundle(serviceReference);
-
 		Set<LiferayOAuth2Scope> locatedScopes = new HashSet<>();
 
 		Map<String, Set<String>> mappedScopeToUnmappedScopes = new HashMap<>();
@@ -196,7 +185,7 @@ public class ScopeLocatorImpl implements ScopeLocator {
 			processedScopes.add(scope);
 
 			locatedScopes.add(
-				new LiferayOAuth2ScopeImpl(applicationName, bundle, scope));
+				new LiferayOAuth2ScopeImpl(applicationName, scope));
 
 			if (!scopeLocatorConfiguration.
 					includeScopesImpliedBeforeScopeMapping()) {
@@ -364,29 +353,6 @@ public class ScopeLocatorImpl implements ScopeLocator {
 		_scopeLocatorConfigurationProvidersScopedServiceTrackerMap.close();
 		_scopeMappersScopedServiceTrackerMap.close();
 		_scopeMatcherFactoriesServiceTrackerMap.close();
-	}
-
-	protected Bundle getBundle(ServiceReference<?> serviceReference) {
-		Object property = serviceReference.getProperty(
-			"original.service.bundleid");
-
-		if (property == null) {
-			return serviceReference.getBundle();
-		}
-
-		long bundleId = GetterUtil.getLong(property, -1L);
-
-		if (bundleId == -1) {
-			return serviceReference.getBundle();
-		}
-
-		Bundle bundle = _bundleContext.getBundle(bundleId);
-
-		if (bundle == null) {
-			return serviceReference.getBundle();
-		}
-
-		return bundle;
 	}
 
 	protected ScopeMatcherFactory getScopeMatcherFactory(long companyId) {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/osgi/commands/OAuth2OSGiCommands.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/osgi/commands/OAuth2OSGiCommands.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 
+import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -58,10 +59,22 @@ public class OAuth2OSGiCommands {
 				Comparator.comparing(LiferayOAuth2Scope::getScope));
 
 			for (LiferayOAuth2Scope liferayOAuth2Scope : liferayOAuth2Scopes) {
-				System.out.println(
-					StringBundler.concat(
-						"    ", liferayOAuth2Scope.getScope(), " (",
-						liferayOAuth2Scope.getApplicationName(), ")"));
+				Bundle bundle = liferayOAuth2Scope.getBundle();
+
+				if (bundle == null) {
+					System.out.println(
+						StringBundler.concat(
+							"    ", liferayOAuth2Scope.getScope(), " (",
+							liferayOAuth2Scope.getApplicationName(),
+							" [unavailable])"));
+				}
+				else {
+					System.out.println(
+						StringBundler.concat(
+							"    ", liferayOAuth2Scope.getScope(), " (",
+							liferayOAuth2Scope.getApplicationName(), " [",
+							bundle.getBundleId(), "])"));
+				}
 			}
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/osgi/commands/OAuth2OSGiCommands.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/osgi/commands/OAuth2OSGiCommands.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 
-import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -59,13 +58,10 @@ public class OAuth2OSGiCommands {
 				Comparator.comparing(LiferayOAuth2Scope::getScope));
 
 			for (LiferayOAuth2Scope liferayOAuth2Scope : liferayOAuth2Scopes) {
-				Bundle bundle = liferayOAuth2Scope.getBundle();
-
 				System.out.println(
 					StringBundler.concat(
 						"    ", liferayOAuth2Scope.getScope(), " (",
-						liferayOAuth2Scope.getApplicationName(), " [",
-						bundle.getBundleId(), "])"));
+						liferayOAuth2Scope.getApplicationName(), ")"));
 			}
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/LiferayOAuth2Scope.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/LiferayOAuth2Scope.java
@@ -14,8 +14,6 @@
 
 package com.liferay.oauth2.provider.scope.liferay;
 
-import org.osgi.framework.Bundle;
-
 /**
  * Represents an application exported scope for Liferay's OAuth2 Provider
  * framework.
@@ -31,14 +29,6 @@ public interface LiferayOAuth2Scope {
 	 * @return the non-<code>null</code> application name
 	 */
 	public String getApplicationName();
-
-	/**
-	 * Returns the OSGi bundle context where the application and scope are
-	 * published.
-	 *
-	 * @return the non-<code>null</code> OSGi bundle
-	 */
-	public Bundle getBundle();
 
 	/**
 	 * Returns the scope name as registered in the OAuth2 Provider framework.

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/LiferayOAuth2Scope.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/LiferayOAuth2Scope.java
@@ -14,6 +14,8 @@
 
 package com.liferay.oauth2.provider.scope.liferay;
 
+import org.osgi.framework.Bundle;
+
 /**
  * Represents an application exported scope for Liferay's OAuth2 Provider
  * framework.
@@ -29,6 +31,14 @@ public interface LiferayOAuth2Scope {
 	 * @return the non-<code>null</code> application name
 	 */
 	public String getApplicationName();
+
+	/**
+	 * Returns the OSGi bundle context where the application and scope are
+	 * published.
+	 *
+	 * @return the non-<code>null</code> OSGi bundle
+	 */
+	public Bundle getBundle();
 
 	/**
 	 * Returns the scope name as registered in the OAuth2 Provider framework.

--- a/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
@@ -20,4 +20,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":core:registry-api")
+
+	testCompile group: "junit", name: "junit", version: "4.12"
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
@@ -155,11 +155,10 @@
 		<finder name="OAuth2ApplicationScopeAliasesId" return-type="Collection">
 			<finder-column name="oAuth2ApplicationScopeAliasesId" />
 		</finder>
-		<finder name="C_O_A_B_S" return-type="OAuth2ScopeGrant">
+		<finder name="C_O_A_S" return-type="OAuth2ScopeGrant">
 			<finder-column name="companyId" />
 			<finder-column name="oAuth2ApplicationScopeAliasesId" />
 			<finder-column name="applicationName" />
-			<finder-column name="bundleSymbolicName" />
 			<finder-column name="scope" />
 		</finder>
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ScopeGrantModelImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ScopeGrantModelImpl.java
@@ -102,16 +102,14 @@ public class OAuth2ScopeGrantModelImpl
 
 	public static final long APPLICATIONNAME_COLUMN_BITMASK = 1L;
 
-	public static final long BUNDLESYMBOLICNAME_COLUMN_BITMASK = 2L;
-
-	public static final long COMPANYID_COLUMN_BITMASK = 4L;
+	public static final long COMPANYID_COLUMN_BITMASK = 2L;
 
 	public static final long OAUTH2APPLICATIONSCOPEALIASESID_COLUMN_BITMASK =
-		8L;
+		4L;
 
-	public static final long SCOPE_COLUMN_BITMASK = 16L;
+	public static final long SCOPE_COLUMN_BITMASK = 8L;
 
-	public static final long OAUTH2SCOPEGRANTID_COLUMN_BITMASK = 32L;
+	public static final long OAUTH2SCOPEGRANTID_COLUMN_BITMASK = 16L;
 
 	public static void setEntityCacheEnabled(boolean entityCacheEnabled) {
 		_entityCacheEnabled = entityCacheEnabled;
@@ -403,17 +401,7 @@ public class OAuth2ScopeGrantModelImpl
 
 	@Override
 	public void setBundleSymbolicName(String bundleSymbolicName) {
-		_columnBitmask |= BUNDLESYMBOLICNAME_COLUMN_BITMASK;
-
-		if (_originalBundleSymbolicName == null) {
-			_originalBundleSymbolicName = _bundleSymbolicName;
-		}
-
 		_bundleSymbolicName = bundleSymbolicName;
-	}
-
-	public String getOriginalBundleSymbolicName() {
-		return GetterUtil.getString(_originalBundleSymbolicName);
 	}
 
 	@Override
@@ -576,9 +564,6 @@ public class OAuth2ScopeGrantModelImpl
 		oAuth2ScopeGrantModelImpl._originalApplicationName =
 			oAuth2ScopeGrantModelImpl._applicationName;
 
-		oAuth2ScopeGrantModelImpl._originalBundleSymbolicName =
-			oAuth2ScopeGrantModelImpl._bundleSymbolicName;
-
 		oAuth2ScopeGrantModelImpl._originalScope =
 			oAuth2ScopeGrantModelImpl._scope;
 
@@ -718,7 +703,6 @@ public class OAuth2ScopeGrantModelImpl
 	private String _applicationName;
 	private String _originalApplicationName;
 	private String _bundleSymbolicName;
-	private String _originalBundleSymbolicName;
 	private String _scope;
 	private String _originalScope;
 	private String _scopeAliases;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -36,6 +36,7 @@ import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2Scope;
 import com.liferay.oauth2.provider.service.base.OAuth2ApplicationLocalServiceBaseImpl;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.portal.aop.AopService;
@@ -78,6 +79,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -93,6 +95,89 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class OAuth2ApplicationLocalServiceImpl
 	extends OAuth2ApplicationLocalServiceBaseImpl {
+
+	@Override
+	public OAuth2Application addOAuth2Application(
+			long companyId, long userId, String userName,
+			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,
+			String clientId, int clientProfile, String clientSecret,
+			String description, List<String> featuresList, String homePageURL,
+			long iconFileEntryId, String name, String privacyPolicyURL,
+			List<String> redirectURIsList,
+			Consumer<OAuth2Scope.Builder> builderConsumer,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		if (allowedGrantTypesList == null) {
+			allowedGrantTypesList = new ArrayList<>();
+		}
+
+		if (Validator.isBlank(clientId)) {
+			clientId = OAuth2SecureRandomGenerator.generateClientId();
+		}
+		else {
+			clientId = StringUtil.trim(clientId);
+		}
+
+		homePageURL = StringUtil.trim(homePageURL);
+		name = StringUtil.trim(name);
+		privacyPolicyURL = StringUtil.trim(privacyPolicyURL);
+
+		if (redirectURIsList == null) {
+			redirectURIsList = new ArrayList<>();
+		}
+
+		validate(
+			companyId, allowedGrantTypesList, clientId, clientProfile,
+			clientSecret, homePageURL, name, privacyPolicyURL,
+			redirectURIsList);
+
+		long oAuth2ApplicationId = counterLocalService.increment(
+			OAuth2Application.class.getName());
+
+		User user = _userLocalService.getUser(clientCredentialUserId);
+
+		OAuth2Application oAuth2Application =
+			oAuth2ApplicationPersistence.create(oAuth2ApplicationId);
+
+		oAuth2Application.setCompanyId(companyId);
+		oAuth2Application.setUserId(userId);
+		oAuth2Application.setUserName(userName);
+		oAuth2Application.setCreateDate(new Date());
+		oAuth2Application.setModifiedDate(new Date());
+		oAuth2Application.setAllowedGrantTypesList(allowedGrantTypesList);
+		oAuth2Application.setClientCredentialUserId(user.getUserId());
+		oAuth2Application.setClientCredentialUserName(user.getScreenName());
+		oAuth2Application.setClientId(clientId);
+		oAuth2Application.setClientProfile(clientProfile);
+		oAuth2Application.setClientSecret(clientSecret);
+		oAuth2Application.setDescription(description);
+		oAuth2Application.setFeaturesList(featuresList);
+		oAuth2Application.setHomePageURL(homePageURL);
+		oAuth2Application.setIconFileEntryId(iconFileEntryId);
+		oAuth2Application.setName(name);
+		oAuth2Application.setPrivacyPolicyURL(privacyPolicyURL);
+		oAuth2Application.setRedirectURIsList(redirectURIsList);
+
+		if (builderConsumer != null) {
+			OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
+				_oAuth2ApplicationScopeAliasesLocalService.
+					addOAuth2ApplicationScopeAliases(
+						companyId, userId, userName, oAuth2ApplicationId,
+						builderConsumer);
+
+			oAuth2Application.setOAuth2ApplicationScopeAliasesId(
+				oAuth2ApplicationScopeAliases.
+					getOAuth2ApplicationScopeAliasesId());
+		}
+
+		resourceLocalService.addResources(
+			oAuth2Application.getCompanyId(), 0, oAuth2Application.getUserId(),
+			OAuth2Application.class.getName(),
+			oAuth2Application.getOAuth2ApplicationId(), false, false, false);
+
+		return oAuth2ApplicationPersistence.update(oAuth2Application);
+	}
 
 	@Override
 	public OAuth2Application addOAuth2Application(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
 import com.liferay.oauth2.provider.model.OAuth2ScopeGrant;
 import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
+import com.liferay.oauth2.provider.service.OAuth2Scope;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.oauth2.provider.service.base.OAuth2ApplicationScopeAliasesLocalServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
@@ -27,6 +28,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -36,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -52,6 +55,24 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 	extends OAuth2ApplicationScopeAliasesLocalServiceBaseImpl {
+
+	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
+			long companyId, long userId, String userName,
+			long oAuth2ApplicationId,
+			Consumer<OAuth2Scope.Builder> builderConsumer)
+		throws PortalException {
+
+		Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			simpleEntryScopeAliases = new HashMap<>();
+
+		builderConsumer.accept(
+			new OAuth2ScopeBuilderImpl(simpleEntryScopeAliases));
+
+		return _addOAuth2ApplicationScopeAliases(
+			companyId, userId, userName, oAuth2ApplicationId,
+			_getLiferayOAuth2ScopesScopeAliases(
+				companyId, simpleEntryScopeAliases));
+	}
 
 	@Override
 	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
@@ -202,6 +223,73 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 		}
 	}
 
+	protected static class OAuth2ScopeBuilderImpl
+		implements OAuth2Scope.Builder,
+				   OAuth2Scope.Builder.ApplicationScopeAssigner,
+				   OAuth2Scope.Builder.ApplicationScope {
+
+		public OAuth2ScopeBuilderImpl(
+			Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+				simpleEntryScopeAliases) {
+
+			_simpleEntryScopeAliases = simpleEntryScopeAliases;
+			_scopes = new ArrayList<>();
+			_scopeAliases = new ArrayList<>();
+		}
+
+		public ApplicationScope assignScope(Collection<String> scope) {
+			_flushScopes();
+
+			_scopes.addAll(scope);
+
+			return this;
+		}
+
+		@Override
+		public void forApplication(
+			String applicationName,
+			Consumer<ApplicationScopeAssigner>
+				applicationScopeAssignerConsumer) {
+
+			_applicationName = applicationName;
+
+			applicationScopeAssignerConsumer.accept(this);
+
+			_flushScopes();
+		}
+
+		@Override
+		public void mapToScopeAlias(Collection<String> scopeAliases) {
+			_scopeAliases = scopeAliases;
+		}
+
+		private void _flushScopes() {
+			for (String scope : _scopes) {
+				List<String> scopeAliasList =
+					_simpleEntryScopeAliases.computeIfAbsent(
+						new AbstractMap.SimpleEntry<>(_applicationName, scope),
+						s -> new ArrayList<>());
+
+				for (String scopeAlias : _scopeAliases) {
+					if (!scopeAliasList.contains(scopeAlias)) {
+						scopeAliasList.add(scopeAlias);
+					}
+				}
+			}
+
+			_scopes.clear();
+
+			_scopeAliases = _scopes;
+		}
+
+		private String _applicationName;
+		private Collection<String> _scopeAliases;
+		private final Collection<String> _scopes;
+		private final Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			_simpleEntryScopeAliases;
+
+	}
+
 	private OAuth2ApplicationScopeAliases _addOAuth2ApplicationScopeAliases(
 			long companyId, long userId, String userName,
 			long oAuth2ApplicationId,
@@ -255,6 +343,24 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 		}
 
 		return liferayOAuth2ScopesScopeAliases;
+	}
+
+	private Map<LiferayOAuth2Scope, List<String>>
+		_getLiferayOAuth2ScopesScopeAliases(
+			long companyId,
+			Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+				simpleEntryScopeAliases) {
+
+		Map<LiferayOAuth2Scope, List<String>> liferayOAuth2ScopeListMap =
+			new HashMap<>();
+
+		simpleEntryScopeAliases.forEach(
+			(simpleEntry, scopeAliases) -> liferayOAuth2ScopeListMap.put(
+				_scopeLocator.getLiferayOAuth2Scope(
+					companyId, simpleEntry.getKey(), simpleEntry.getValue()),
+				scopeAliases));
+
+		return liferayOAuth2ScopeListMap;
 	}
 
 	private List<String> _getScopeAliasesList(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -262,14 +262,13 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 		Stream<OAuth2ScopeGrant> stream = oAuth2ScopeGrants.stream();
 
-		Set<String> scopeAliases = stream.flatMap(
+		return stream.flatMap(
 			oa2sg -> oa2sg.getScopeAliasesList(
 			).stream()
+		).distinct(
 		).collect(
-			Collectors.toSet()
+			Collectors.toList()
 		);
-
-		return new ArrayList<>(scopeAliases);
 	}
 
 	private boolean _hasUpToDateScopeGrants(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -211,8 +211,7 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 			_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
 				companyId, oAuth2ApplicationScopeAliasesId,
-				simpleEntry.getKey(), null, simpleEntry.getValue(),
-				entry.getValue());
+				simpleEntry.getKey(), simpleEntry.getValue(), entry.getValue());
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -42,7 +42,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -70,8 +69,7 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 		return _addOAuth2ApplicationScopeAliases(
 			companyId, userId, userName, oAuth2ApplicationId,
-			_getLiferayOAuth2ScopesScopeAliases(
-				companyId, simpleEntryScopeAliases));
+			simpleEntryScopeAliases);
 	}
 
 	@Override
@@ -87,12 +85,9 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 			}
 		}
 
-		Map<LiferayOAuth2Scope, List<String>> liferayOAuth2ScopesScopeAliases =
-			_getLiferayOAuth2ScopesScopeAliases(companyId, scopeAliasesList);
-
 		return _addOAuth2ApplicationScopeAliases(
 			companyId, userId, userName, oAuth2ApplicationId,
-			liferayOAuth2ScopesScopeAliases);
+			_getLiferayOAuth2ScopesScopeAliases(companyId, scopeAliasesList));
 	}
 
 	@Override
@@ -179,12 +174,12 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 		List<String> scopeAliasesList = _getScopeAliasesList(oAuth2ScopeGrants);
 
-		Map<LiferayOAuth2Scope, List<String>> liferayOAuth2ScopesScopeAliases =
-			_getLiferayOAuth2ScopesScopeAliases(
+		Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			simpleEntryScopeAliases = _getLiferayOAuth2ScopesScopeAliases(
 				oAuth2ApplicationScopeAliases.getCompanyId(), scopeAliasesList);
 
 		if (_hasUpToDateScopeGrants(
-				oAuth2ScopeGrants, liferayOAuth2ScopesScopeAliases)) {
+				oAuth2ScopeGrants, simpleEntryScopeAliases)) {
 
 			return oAuth2ApplicationScopeAliases;
 		}
@@ -195,7 +190,7 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 				oAuth2ApplicationScopeAliases.getUserId(),
 				oAuth2ApplicationScopeAliases.getUserName(),
 				oAuth2ApplicationScopeAliases.getOAuth2ApplicationId(),
-				liferayOAuth2ScopesScopeAliases);
+				simpleEntryScopeAliases);
 		}
 		catch (PortalException pe) {
 			throw new IllegalArgumentException(pe);
@@ -204,21 +199,19 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 	protected void createScopeGrants(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			Map<LiferayOAuth2Scope, List<String>>
-				liferayOAuth2ScopesScopeAliases)
+			Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+				simpleEntryScopeAliases)
 		throws PortalException {
 
-		for (Map.Entry<LiferayOAuth2Scope, List<String>> entry :
-				liferayOAuth2ScopesScopeAliases.entrySet()) {
+		for (Map.Entry<AbstractMap.SimpleEntry<String, String>, List<String>>
+				entry : simpleEntryScopeAliases.entrySet()) {
 
-			LiferayOAuth2Scope liferayOAuth2Scope = entry.getKey();
-
-			Bundle bundle = liferayOAuth2Scope.getBundle();
+			AbstractMap.SimpleEntry<String, String> simpleEntry =
+				entry.getKey();
 
 			_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
 				companyId, oAuth2ApplicationScopeAliasesId,
-				liferayOAuth2Scope.getApplicationName(),
-				bundle.getSymbolicName(), liferayOAuth2Scope.getScope(),
+				simpleEntry.getKey(), null, simpleEntry.getValue(),
 				entry.getValue());
 		}
 	}
@@ -293,8 +286,8 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 	private OAuth2ApplicationScopeAliases _addOAuth2ApplicationScopeAliases(
 			long companyId, long userId, String userName,
 			long oAuth2ApplicationId,
-			Map<LiferayOAuth2Scope, List<String>>
-				liferayOAuth2ScopesScopeAliases)
+			Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+				simpleEntryScopeAliases)
 		throws PortalException {
 
 		long oAuth2ApplicationScopeAliasesId = counterLocalService.increment(
@@ -317,17 +310,17 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 		createScopeGrants(
 			companyId, oAuth2ApplicationScopeAliasesId,
-			liferayOAuth2ScopesScopeAliases);
+			simpleEntryScopeAliases);
 
 		return oAuth2ApplicationScopeAliases;
 	}
 
-	private Map<LiferayOAuth2Scope, List<String>>
+	private Map<AbstractMap.SimpleEntry<String, String>, List<String>>
 		_getLiferayOAuth2ScopesScopeAliases(
 			long companyId, List<String> scopeAliasesList) {
 
-		Map<LiferayOAuth2Scope, List<String>> liferayOAuth2ScopesScopeAliases =
-			new HashMap<>();
+		Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			simpleEntryScopeAliases = new HashMap<>();
 
 		for (String scopeAlias : ListUtil.sort(scopeAliasesList)) {
 			for (LiferayOAuth2Scope liferayOAuth2Scope :
@@ -335,32 +328,17 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 						companyId, scopeAlias)) {
 
 				List<String> scopeAliases =
-					liferayOAuth2ScopesScopeAliases.computeIfAbsent(
-						liferayOAuth2Scope, x -> new ArrayList<>());
+					simpleEntryScopeAliases.computeIfAbsent(
+						new AbstractMap.SimpleEntry<>(
+							liferayOAuth2Scope.getApplicationName(),
+							liferayOAuth2Scope.getScope()),
+						x -> new ArrayList<>());
 
 				scopeAliases.add(scopeAlias);
 			}
 		}
 
-		return liferayOAuth2ScopesScopeAliases;
-	}
-
-	private Map<LiferayOAuth2Scope, List<String>>
-		_getLiferayOAuth2ScopesScopeAliases(
-			long companyId,
-			Map<AbstractMap.SimpleEntry<String, String>, List<String>>
-				simpleEntryScopeAliases) {
-
-		Map<LiferayOAuth2Scope, List<String>> liferayOAuth2ScopeListMap =
-			new HashMap<>();
-
-		simpleEntryScopeAliases.forEach(
-			(simpleEntry, scopeAliases) -> liferayOAuth2ScopeListMap.put(
-				_scopeLocator.getLiferayOAuth2Scope(
-					companyId, simpleEntry.getKey(), simpleEntry.getValue()),
-				scopeAliases));
-
-		return liferayOAuth2ScopeListMap;
+		return simpleEntryScopeAliases;
 	}
 
 	private List<String> _getScopeAliasesList(
@@ -379,33 +357,29 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 	private boolean _hasUpToDateScopeGrants(
 		Collection<OAuth2ScopeGrant> oAuth2ScopeGrants,
-		Map<LiferayOAuth2Scope, List<String>> liferayOAuth2ScopesScopeAliases) {
+		Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			simpleEntryScopeAliases) {
 
-		if (liferayOAuth2ScopesScopeAliases.size() !=
-				oAuth2ScopeGrants.size()) {
-
+		if (simpleEntryScopeAliases.size() != oAuth2ScopeGrants.size()) {
 			return false;
 		}
 
 		oAuth2ScopeGrants = new ArrayList<>(oAuth2ScopeGrants);
 
-		for (Map.Entry<LiferayOAuth2Scope, List<String>> entry :
-				liferayOAuth2ScopesScopeAliases.entrySet()) {
+		for (Map.Entry<AbstractMap.SimpleEntry<String, String>, List<String>>
+				entry : simpleEntryScopeAliases.entrySet()) {
 
-			LiferayOAuth2Scope liferayOAuth2Scope = entry.getKey();
+			AbstractMap.SimpleEntry<String, String> simpleEntry =
+				entry.getKey();
 			List<String> scopeAliases = entry.getValue();
-			Bundle bundle = liferayOAuth2Scope.getBundle();
 
 			boolean found = oAuth2ScopeGrants.removeIf(
 				oAuth2ScopeGrant -> {
 					if (Objects.equals(
-							liferayOAuth2Scope.getApplicationName(),
+							simpleEntry.getKey(),
 							oAuth2ScopeGrant.getApplicationName()) &&
 						Objects.equals(
-							bundle.getSymbolicName(),
-							oAuth2ScopeGrant.getBundleSymbolicName()) &&
-						Objects.equals(
-							liferayOAuth2Scope.getScope(),
+							simpleEntry.getValue(),
 							oAuth2ScopeGrant.getScope())) {
 
 						List<String> oAuth2ScopeGrantScopeAliases =

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeGrantLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeGrantLocalServiceImpl.java
@@ -44,23 +44,13 @@ public class OAuth2ScopeGrantLocalServiceImpl
 	@Override
 	public OAuth2ScopeGrant createOAuth2ScopeGrant(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope)
-		throws DuplicateOAuth2ScopeGrantException {
-
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public OAuth2ScopeGrant createOAuth2ScopeGrant(
-			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope,
-			List<String> scopeAliases)
+			String applicationName, String scope, List<String> scopeAliases)
 		throws DuplicateOAuth2ScopeGrantException {
 
 		OAuth2ScopeGrant oAuth2ScopeGrant =
-			oAuth2ScopeGrantPersistence.fetchByC_O_A_B_S(
+			oAuth2ScopeGrantPersistence.fetchByC_O_A_S(
 				companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-				bundleSymbolicName, scope);
+				scope);
 
 		if (oAuth2ScopeGrant != null) {
 			throw new DuplicateOAuth2ScopeGrantException();
@@ -76,12 +66,20 @@ public class OAuth2ScopeGrantLocalServiceImpl
 		oAuth2ScopeGrant.setOAuth2ApplicationScopeAliasesId(
 			oAuth2ApplicationScopeAliasesId);
 		oAuth2ScopeGrant.setApplicationName(applicationName);
-		oAuth2ScopeGrant.setBundleSymbolicName(bundleSymbolicName);
 		oAuth2ScopeGrant.setScope(scope);
 
 		oAuth2ScopeGrant.setScopeAliasesList(scopeAliases);
 
 		return oAuth2ScopeGrantPersistence.update(oAuth2ScopeGrant);
+	}
+
+	@Override
+	public OAuth2ScopeGrant createOAuth2ScopeGrant(
+			long companyId, long oAuth2ApplicationScopeAliasesId,
+			String applicationName, String bundleSymbolicName, String scope)
+		throws DuplicateOAuth2ScopeGrantException {
+
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -121,11 +119,10 @@ public class OAuth2ScopeGrantLocalServiceImpl
 
 	@Override
 	public Collection<OAuth2ScopeGrant> getOAuth2ScopeGrants(
-		long companyId, String applicationName, String bundleSymbolicName,
-		String accessTokenContent) {
+		long companyId, String applicationName, String accessTokenContent) {
 
-		return oAuth2ScopeGrantFinder.findByC_A_B_A(
-			companyId, applicationName, bundleSymbolicName, accessTokenContent);
+		return oAuth2ScopeGrantFinder.findByC_A_A(
+			companyId, applicationName, accessTokenContent);
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeGrantLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeGrantLocalServiceImpl.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -179,16 +178,6 @@ public class OAuth2ScopeGrantLocalServiceImpl
 
 		if (!Objects.equals(
 				oAuth2ScopeGrant.getScope(), liferayOAuth2Scope.getScope())) {
-
-			return false;
-		}
-
-		Bundle bundle = liferayOAuth2Scope.getBundle();
-
-		String bundleSymbolicName = bundle.getSymbolicName();
-
-		if (!Objects.equals(
-				oAuth2ScopeGrant.getBundleSymbolicName(), bundleSymbolicName)) {
 
 			return false;
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ScopeGrantFinderImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ScopeGrantFinderImpl.java
@@ -40,20 +40,19 @@ import org.osgi.service.component.annotations.Reference;
 public class OAuth2ScopeGrantFinderImpl
 	extends OAuth2ScopeGrantFinderBaseImpl implements OAuth2ScopeGrantFinder {
 
-	public static final String FIND_BY_C_A_B_A =
-		OAuth2ScopeGrantFinder.class.getName() + ".findByC_A_B_A";
+	public static final String FIND_BY_C_A_A =
+		OAuth2ScopeGrantFinder.class.getName() + ".findByC_A_A";
 
 	@Override
-	public Collection<OAuth2ScopeGrant> findByC_A_B_A(
-		long companyId, String applicationName, String bundleSymbolicName,
-		String accessTokenContent) {
+	public Collection<OAuth2ScopeGrant> findByC_A_A(
+		long companyId, String applicationName, String accessTokenContent) {
 
 		Session session = null;
 
 		try {
 			session = openSession();
 
-			String sql = _customSQL.get(getClass(), FIND_BY_C_A_B_A);
+			String sql = _customSQL.get(getClass(), FIND_BY_C_A_A);
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 
@@ -64,7 +63,6 @@ public class OAuth2ScopeGrantFinderImpl
 
 			qPos.add(companyId);
 			qPos.add(applicationName);
-			qPos.add(bundleSymbolicName);
 			qPos.add(accessTokenContent.hashCode());
 
 			List<Object[]> rows = (List<Object[]>)QueryUtil.list(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ScopeGrantPersistenceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ScopeGrantPersistenceImpl.java
@@ -635,32 +635,30 @@ public class OAuth2ScopeGrantPersistenceImpl
 		_FINDER_COLUMN_OAUTH2APPLICATIONSCOPEALIASESID_OAUTH2APPLICATIONSCOPEALIASESID_2 =
 			"oAuth2ScopeGrant.oAuth2ApplicationScopeAliasesId = ?";
 
-	private FinderPath _finderPathFetchByC_O_A_B_S;
-	private FinderPath _finderPathCountByC_O_A_B_S;
+	private FinderPath _finderPathFetchByC_O_A_S;
+	private FinderPath _finderPathCountByC_O_A_S;
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or throws a <code>NoSuchOAuth2ScopeGrantException</code> if it could not be found.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or throws a <code>NoSuchOAuth2ScopeGrantException</code> if it could not be found.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the matching o auth2 scope grant
 	 * @throws NoSuchOAuth2ScopeGrantException if a matching o auth2 scope grant could not be found
 	 */
 	@Override
-	public OAuth2ScopeGrant findByC_O_A_B_S(
+	public OAuth2ScopeGrant findByC_O_A_S(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope)
+			String applicationName, String scope)
 		throws NoSuchOAuth2ScopeGrantException {
 
-		OAuth2ScopeGrant oAuth2ScopeGrant = fetchByC_O_A_B_S(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope);
+		OAuth2ScopeGrant oAuth2ScopeGrant = fetchByC_O_A_S(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope);
 
 		if (oAuth2ScopeGrant == null) {
-			StringBundler msg = new StringBundler(12);
+			StringBundler msg = new StringBundler(10);
 
 			msg.append(_NO_SUCH_ENTITY_WITH_KEY);
 
@@ -672,9 +670,6 @@ public class OAuth2ScopeGrantPersistenceImpl
 
 			msg.append(", applicationName=");
 			msg.append(applicationName);
-
-			msg.append(", bundleSymbolicName=");
-			msg.append(bundleSymbolicName);
 
 			msg.append(", scope=");
 			msg.append(scope);
@@ -692,44 +687,40 @@ public class OAuth2ScopeGrantPersistenceImpl
 	}
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the matching o auth2 scope grant, or <code>null</code> if a matching o auth2 scope grant could not be found
 	 */
 	@Override
-	public OAuth2ScopeGrant fetchByC_O_A_B_S(
+	public OAuth2ScopeGrant fetchByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope) {
+		String applicationName, String scope) {
 
-		return fetchByC_O_A_B_S(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope, true);
+		return fetchByC_O_A_S(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope,
+			true);
 	}
 
 	/**
-	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching o auth2 scope grant, or <code>null</code> if a matching o auth2 scope grant could not be found
 	 */
 	@Override
-	public OAuth2ScopeGrant fetchByC_O_A_B_S(
+	public OAuth2ScopeGrant fetchByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope,
-		boolean useFinderCache) {
+		String applicationName, String scope, boolean useFinderCache) {
 
 		applicationName = Objects.toString(applicationName, "");
-		bundleSymbolicName = Objects.toString(bundleSymbolicName, "");
 		scope = Objects.toString(scope, "");
 
 		Object[] finderArgs = null;
@@ -737,7 +728,7 @@ public class OAuth2ScopeGrantPersistenceImpl
 		if (useFinderCache) {
 			finderArgs = new Object[] {
 				companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-				bundleSymbolicName, scope
+				scope
 			};
 		}
 
@@ -745,7 +736,7 @@ public class OAuth2ScopeGrantPersistenceImpl
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_O_A_B_S, finderArgs, this);
+				_finderPathFetchByC_O_A_S, finderArgs, this);
 		}
 
 		if (result instanceof OAuth2ScopeGrant) {
@@ -756,9 +747,6 @@ public class OAuth2ScopeGrantPersistenceImpl
 					oAuth2ScopeGrant.getOAuth2ApplicationScopeAliasesId()) ||
 				!Objects.equals(
 					applicationName, oAuth2ScopeGrant.getApplicationName()) ||
-				!Objects.equals(
-					bundleSymbolicName,
-					oAuth2ScopeGrant.getBundleSymbolicName()) ||
 				!Objects.equals(scope, oAuth2ScopeGrant.getScope())) {
 
 				result = null;
@@ -766,46 +754,35 @@ public class OAuth2ScopeGrantPersistenceImpl
 		}
 
 		if (result == null) {
-			StringBundler query = new StringBundler(7);
+			StringBundler query = new StringBundler(6);
 
 			query.append(_SQL_SELECT_OAUTH2SCOPEGRANT_WHERE);
 
-			query.append(_FINDER_COLUMN_C_O_A_B_S_COMPANYID_2);
+			query.append(_FINDER_COLUMN_C_O_A_S_COMPANYID_2);
 
 			query.append(
-				_FINDER_COLUMN_C_O_A_B_S_OAUTH2APPLICATIONSCOPEALIASESID_2);
+				_FINDER_COLUMN_C_O_A_S_OAUTH2APPLICATIONSCOPEALIASESID_2);
 
 			boolean bindApplicationName = false;
 
 			if (applicationName.isEmpty()) {
-				query.append(_FINDER_COLUMN_C_O_A_B_S_APPLICATIONNAME_3);
+				query.append(_FINDER_COLUMN_C_O_A_S_APPLICATIONNAME_3);
 			}
 			else {
 				bindApplicationName = true;
 
-				query.append(_FINDER_COLUMN_C_O_A_B_S_APPLICATIONNAME_2);
-			}
-
-			boolean bindBundleSymbolicName = false;
-
-			if (bundleSymbolicName.isEmpty()) {
-				query.append(_FINDER_COLUMN_C_O_A_B_S_BUNDLESYMBOLICNAME_3);
-			}
-			else {
-				bindBundleSymbolicName = true;
-
-				query.append(_FINDER_COLUMN_C_O_A_B_S_BUNDLESYMBOLICNAME_2);
+				query.append(_FINDER_COLUMN_C_O_A_S_APPLICATIONNAME_2);
 			}
 
 			boolean bindScope = false;
 
 			if (scope.isEmpty()) {
-				query.append(_FINDER_COLUMN_C_O_A_B_S_SCOPE_3);
+				query.append(_FINDER_COLUMN_C_O_A_S_SCOPE_3);
 			}
 			else {
 				bindScope = true;
 
-				query.append(_FINDER_COLUMN_C_O_A_B_S_SCOPE_2);
+				query.append(_FINDER_COLUMN_C_O_A_S_SCOPE_2);
 			}
 
 			String sql = query.toString();
@@ -827,10 +804,6 @@ public class OAuth2ScopeGrantPersistenceImpl
 					qPos.add(applicationName);
 				}
 
-				if (bindBundleSymbolicName) {
-					qPos.add(bundleSymbolicName);
-				}
-
 				if (bindScope) {
 					qPos.add(scope);
 				}
@@ -840,7 +813,7 @@ public class OAuth2ScopeGrantPersistenceImpl
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_O_A_B_S, finderArgs, list);
+							_finderPathFetchByC_O_A_S, finderArgs, list);
 					}
 				}
 				else {
@@ -851,12 +824,12 @@ public class OAuth2ScopeGrantPersistenceImpl
 							if (!useFinderCache) {
 								finderArgs = new Object[] {
 									companyId, oAuth2ApplicationScopeAliasesId,
-									applicationName, bundleSymbolicName, scope
+									applicationName, scope
 								};
 							}
 
 							_log.warn(
-								"OAuth2ScopeGrantPersistenceImpl.fetchByC_O_A_B_S(long, long, String, String, String, boolean) with parameters (" +
+								"OAuth2ScopeGrantPersistenceImpl.fetchByC_O_A_S(long, long, String, String, boolean) with parameters (" +
 									StringUtil.merge(finderArgs) +
 										") yields a result set with more than 1 result. This violates the logical unique restriction. There is no order guarantee on which result is returned by this finder.");
 						}
@@ -872,7 +845,7 @@ public class OAuth2ScopeGrantPersistenceImpl
 			catch (Exception e) {
 				if (useFinderCache) {
 					finderCache.removeResult(
-						_finderPathFetchByC_O_A_B_S, finderArgs);
+						_finderPathFetchByC_O_A_S, finderArgs);
 				}
 
 				throw processException(e);
@@ -891,97 +864,81 @@ public class OAuth2ScopeGrantPersistenceImpl
 	}
 
 	/**
-	 * Removes the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63; from the database.
+	 * Removes the o auth2 scope grant where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63; from the database.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the o auth2 scope grant that was removed
 	 */
 	@Override
-	public OAuth2ScopeGrant removeByC_O_A_B_S(
+	public OAuth2ScopeGrant removeByC_O_A_S(
 			long companyId, long oAuth2ApplicationScopeAliasesId,
-			String applicationName, String bundleSymbolicName, String scope)
+			String applicationName, String scope)
 		throws NoSuchOAuth2ScopeGrantException {
 
-		OAuth2ScopeGrant oAuth2ScopeGrant = findByC_O_A_B_S(
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope);
+		OAuth2ScopeGrant oAuth2ScopeGrant = findByC_O_A_S(
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope);
 
 		return remove(oAuth2ScopeGrant);
 	}
 
 	/**
-	 * Returns the number of o auth2 scope grants where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and bundleSymbolicName = &#63; and scope = &#63;.
+	 * Returns the number of o auth2 scope grants where companyId = &#63; and oAuth2ApplicationScopeAliasesId = &#63; and applicationName = &#63; and scope = &#63;.
 	 *
 	 * @param companyId the company ID
 	 * @param oAuth2ApplicationScopeAliasesId the o auth2 application scope aliases ID
 	 * @param applicationName the application name
-	 * @param bundleSymbolicName the bundle symbolic name
 	 * @param scope the scope
 	 * @return the number of matching o auth2 scope grants
 	 */
 	@Override
-	public int countByC_O_A_B_S(
+	public int countByC_O_A_S(
 		long companyId, long oAuth2ApplicationScopeAliasesId,
-		String applicationName, String bundleSymbolicName, String scope) {
+		String applicationName, String scope) {
 
 		applicationName = Objects.toString(applicationName, "");
-		bundleSymbolicName = Objects.toString(bundleSymbolicName, "");
 		scope = Objects.toString(scope, "");
 
-		FinderPath finderPath = _finderPathCountByC_O_A_B_S;
+		FinderPath finderPath = _finderPathCountByC_O_A_S;
 
 		Object[] finderArgs = new Object[] {
-			companyId, oAuth2ApplicationScopeAliasesId, applicationName,
-			bundleSymbolicName, scope
+			companyId, oAuth2ApplicationScopeAliasesId, applicationName, scope
 		};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
 		if (count == null) {
-			StringBundler query = new StringBundler(6);
+			StringBundler query = new StringBundler(5);
 
 			query.append(_SQL_COUNT_OAUTH2SCOPEGRANT_WHERE);
 
-			query.append(_FINDER_COLUMN_C_O_A_B_S_COMPANYID_2);
+			query.append(_FINDER_COLUMN_C_O_A_S_COMPANYID_2);
 
 			query.append(
-				_FINDER_COLUMN_C_O_A_B_S_OAUTH2APPLICATIONSCOPEALIASESID_2);
+				_FINDER_COLUMN_C_O_A_S_OAUTH2APPLICATIONSCOPEALIASESID_2);
 
 			boolean bindApplicationName = false;
 
 			if (applicationName.isEmpty()) {
-				query.append(_FINDER_COLUMN_C_O_A_B_S_APPLICATIONNAME_3);
+				query.append(_FINDER_COLUMN_C_O_A_S_APPLICATIONNAME_3);
 			}
 			else {
 				bindApplicationName = true;
 
-				query.append(_FINDER_COLUMN_C_O_A_B_S_APPLICATIONNAME_2);
-			}
-
-			boolean bindBundleSymbolicName = false;
-
-			if (bundleSymbolicName.isEmpty()) {
-				query.append(_FINDER_COLUMN_C_O_A_B_S_BUNDLESYMBOLICNAME_3);
-			}
-			else {
-				bindBundleSymbolicName = true;
-
-				query.append(_FINDER_COLUMN_C_O_A_B_S_BUNDLESYMBOLICNAME_2);
+				query.append(_FINDER_COLUMN_C_O_A_S_APPLICATIONNAME_2);
 			}
 
 			boolean bindScope = false;
 
 			if (scope.isEmpty()) {
-				query.append(_FINDER_COLUMN_C_O_A_B_S_SCOPE_3);
+				query.append(_FINDER_COLUMN_C_O_A_S_SCOPE_3);
 			}
 			else {
 				bindScope = true;
 
-				query.append(_FINDER_COLUMN_C_O_A_B_S_SCOPE_2);
+				query.append(_FINDER_COLUMN_C_O_A_S_SCOPE_2);
 			}
 
 			String sql = query.toString();
@@ -1001,10 +958,6 @@ public class OAuth2ScopeGrantPersistenceImpl
 
 				if (bindApplicationName) {
 					qPos.add(applicationName);
-				}
-
-				if (bindBundleSymbolicName) {
-					qPos.add(bundleSymbolicName);
 				}
 
 				if (bindScope) {
@@ -1028,29 +981,23 @@ public class OAuth2ScopeGrantPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_O_A_B_S_COMPANYID_2 =
+	private static final String _FINDER_COLUMN_C_O_A_S_COMPANYID_2 =
 		"oAuth2ScopeGrant.companyId = ? AND ";
 
 	private static final String
-		_FINDER_COLUMN_C_O_A_B_S_OAUTH2APPLICATIONSCOPEALIASESID_2 =
+		_FINDER_COLUMN_C_O_A_S_OAUTH2APPLICATIONSCOPEALIASESID_2 =
 			"oAuth2ScopeGrant.oAuth2ApplicationScopeAliasesId = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_O_A_B_S_APPLICATIONNAME_2 =
+	private static final String _FINDER_COLUMN_C_O_A_S_APPLICATIONNAME_2 =
 		"oAuth2ScopeGrant.applicationName = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_O_A_B_S_APPLICATIONNAME_3 =
+	private static final String _FINDER_COLUMN_C_O_A_S_APPLICATIONNAME_3 =
 		"(oAuth2ScopeGrant.applicationName IS NULL OR oAuth2ScopeGrant.applicationName = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_O_A_B_S_BUNDLESYMBOLICNAME_2 =
-		"oAuth2ScopeGrant.bundleSymbolicName = ? AND ";
-
-	private static final String _FINDER_COLUMN_C_O_A_B_S_BUNDLESYMBOLICNAME_3 =
-		"(oAuth2ScopeGrant.bundleSymbolicName IS NULL OR oAuth2ScopeGrant.bundleSymbolicName = '') AND ";
-
-	private static final String _FINDER_COLUMN_C_O_A_B_S_SCOPE_2 =
+	private static final String _FINDER_COLUMN_C_O_A_S_SCOPE_2 =
 		"oAuth2ScopeGrant.scope = ?";
 
-	private static final String _FINDER_COLUMN_C_O_A_B_S_SCOPE_3 =
+	private static final String _FINDER_COLUMN_C_O_A_S_SCOPE_3 =
 		"(oAuth2ScopeGrant.scope IS NULL OR oAuth2ScopeGrant.scope = '')";
 
 	public OAuth2ScopeGrantPersistenceImpl() {
@@ -1079,12 +1026,11 @@ public class OAuth2ScopeGrantPersistenceImpl
 			oAuth2ScopeGrant.getPrimaryKey(), oAuth2ScopeGrant);
 
 		finderCache.putResult(
-			_finderPathFetchByC_O_A_B_S,
+			_finderPathFetchByC_O_A_S,
 			new Object[] {
 				oAuth2ScopeGrant.getCompanyId(),
 				oAuth2ScopeGrant.getOAuth2ApplicationScopeAliasesId(),
 				oAuth2ScopeGrant.getApplicationName(),
-				oAuth2ScopeGrant.getBundleSymbolicName(),
 				oAuth2ScopeGrant.getScope()
 			},
 			oAuth2ScopeGrant);
@@ -1182,15 +1128,13 @@ public class OAuth2ScopeGrantPersistenceImpl
 			oAuth2ScopeGrantModelImpl.getCompanyId(),
 			oAuth2ScopeGrantModelImpl.getOAuth2ApplicationScopeAliasesId(),
 			oAuth2ScopeGrantModelImpl.getApplicationName(),
-			oAuth2ScopeGrantModelImpl.getBundleSymbolicName(),
 			oAuth2ScopeGrantModelImpl.getScope()
 		};
 
 		finderCache.putResult(
-			_finderPathCountByC_O_A_B_S, args, Long.valueOf(1), false);
+			_finderPathCountByC_O_A_S, args, Long.valueOf(1), false);
 		finderCache.putResult(
-			_finderPathFetchByC_O_A_B_S, args, oAuth2ScopeGrantModelImpl,
-			false);
+			_finderPathFetchByC_O_A_S, args, oAuth2ScopeGrantModelImpl, false);
 	}
 
 	protected void clearUniqueFindersCache(
@@ -1202,28 +1146,26 @@ public class OAuth2ScopeGrantPersistenceImpl
 				oAuth2ScopeGrantModelImpl.getCompanyId(),
 				oAuth2ScopeGrantModelImpl.getOAuth2ApplicationScopeAliasesId(),
 				oAuth2ScopeGrantModelImpl.getApplicationName(),
-				oAuth2ScopeGrantModelImpl.getBundleSymbolicName(),
 				oAuth2ScopeGrantModelImpl.getScope()
 			};
 
-			finderCache.removeResult(_finderPathCountByC_O_A_B_S, args);
-			finderCache.removeResult(_finderPathFetchByC_O_A_B_S, args);
+			finderCache.removeResult(_finderPathCountByC_O_A_S, args);
+			finderCache.removeResult(_finderPathFetchByC_O_A_S, args);
 		}
 
 		if ((oAuth2ScopeGrantModelImpl.getColumnBitmask() &
-			 _finderPathFetchByC_O_A_B_S.getColumnBitmask()) != 0) {
+			 _finderPathFetchByC_O_A_S.getColumnBitmask()) != 0) {
 
 			Object[] args = new Object[] {
 				oAuth2ScopeGrantModelImpl.getOriginalCompanyId(),
 				oAuth2ScopeGrantModelImpl.
 					getOriginalOAuth2ApplicationScopeAliasesId(),
 				oAuth2ScopeGrantModelImpl.getOriginalApplicationName(),
-				oAuth2ScopeGrantModelImpl.getOriginalBundleSymbolicName(),
 				oAuth2ScopeGrantModelImpl.getOriginalScope()
 			};
 
-			finderCache.removeResult(_finderPathCountByC_O_A_B_S, args);
-			finderCache.removeResult(_finderPathFetchByC_O_A_B_S, args);
+			finderCache.removeResult(_finderPathCountByC_O_A_S, args);
+			finderCache.removeResult(_finderPathFetchByC_O_A_S, args);
 		}
 	}
 
@@ -2098,28 +2040,25 @@ public class OAuth2ScopeGrantPersistenceImpl
 			"countByOAuth2ApplicationScopeAliasesId",
 			new String[] {Long.class.getName()});
 
-		_finderPathFetchByC_O_A_B_S = new FinderPath(
+		_finderPathFetchByC_O_A_S = new FinderPath(
 			entityCacheEnabled, finderCacheEnabled, OAuth2ScopeGrantImpl.class,
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_O_A_B_S",
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_O_A_S",
 			new String[] {
 				Long.class.getName(), Long.class.getName(),
-				String.class.getName(), String.class.getName(),
-				String.class.getName()
+				String.class.getName(), String.class.getName()
 			},
 			OAuth2ScopeGrantModelImpl.COMPANYID_COLUMN_BITMASK |
 			OAuth2ScopeGrantModelImpl.
 				OAUTH2APPLICATIONSCOPEALIASESID_COLUMN_BITMASK |
 			OAuth2ScopeGrantModelImpl.APPLICATIONNAME_COLUMN_BITMASK |
-			OAuth2ScopeGrantModelImpl.BUNDLESYMBOLICNAME_COLUMN_BITMASK |
 			OAuth2ScopeGrantModelImpl.SCOPE_COLUMN_BITMASK);
 
-		_finderPathCountByC_O_A_B_S = new FinderPath(
+		_finderPathCountByC_O_A_S = new FinderPath(
 			entityCacheEnabled, finderCacheEnabled, Long.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_O_A_B_S",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_O_A_S",
 			new String[] {
 				Long.class.getName(), Long.class.getName(),
-				String.class.getName(), String.class.getName(),
-				String.class.getName()
+				String.class.getName(), String.class.getName()
 			});
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/indexes.sql
@@ -12,4 +12,5 @@ create index IX_10C77BD5 on OAuth2Authorization (refreshTokenContentHash);
 create index IX_719D503E on OAuth2Authorization (userId);
 
 create index IX_88938BF on OAuth2ScopeGrant (companyId, oA2AScopeAliasesId, applicationName[$COLUMN_LENGTH:255$], bundleSymbolicName[$COLUMN_LENGTH:255$], scope[$COLUMN_LENGTH:240$]);
+create index IX_FA64ABD2 on OAuth2ScopeGrant (companyId, oA2AScopeAliasesId, applicationName[$COLUMN_LENGTH:255$], scope[$COLUMN_LENGTH:240$]);
 create index IX_80FCAC23 on OAuth2ScopeGrant (oA2AScopeAliasesId);

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/custom-sql/default.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/custom-sql/default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <custom-sql>
-	<sql id="com.liferay.oauth2.provider.service.persistence.OAuth2ScopeGrantFinder.findByC_A_B_A">
+	<sql id="com.liferay.oauth2.provider.service.persistence.OAuth2ScopeGrantFinder.findByC_A_A">
 		<![CDATA[
 			SELECT
 				{OAuth2ScopeGrant.*}, {OAuth2Authorization.*}
@@ -16,7 +16,6 @@
 			WHERE
 				(OAuth2ScopeGrant.companyId = ?) AND
 				(OAuth2ScopeGrant.applicationName = ?) AND
-				(OAuth2ScopeGrant.bundleSymbolicName = ?) AND
 				(OAuth2Authorization.accessTokenContentHash = ?)
 		]]>
 	</sql>

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/test/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeBuilderImplTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/test/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeBuilderImplTest.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.service.impl;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
+
+import com.liferay.oauth2.provider.service.OAuth2Scope;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.apache.commons.compress.utils.Sets;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author Stian Sigvartsen
+ */
+@RunWith(PowerMockRunner.class)
+public class OAuth2ScopeBuilderImplTest extends PowerMockito {
+
+	@Test
+	public void testApplicationIsolation() {
+		String applicationName1 = "Test.Application1";
+		String applicationName2 = "Test.Application2";
+
+		String[] scopes = {"everything.read", "everything.write"};
+
+		String scopeAlias = "everything";
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases = _exerciseBuilder(
+				builder -> {
+					builder.forApplication(
+						applicationName1,
+						applicationScopeAssigner ->
+							applicationScopeAssigner.assignScope(
+								scopes
+							).mapToScopeAlias(
+								_getApplicationScopeAlias(
+									applicationName1, scopeAlias)
+							));
+
+					builder.forApplication(
+						applicationName2,
+						applicationScopeAssigner ->
+							applicationScopeAssigner.assignScope(
+								scopes
+							).mapToScopeAlias(
+								_getApplicationScopeAlias(
+									applicationName2, scopeAlias)
+							));
+				});
+
+		simpeEntryScopeAliases.forEach(
+			(key, value) -> {
+				Assert.assertThat(value, not(hasItems(scopes)));
+				Assert.assertEquals(1, value.size());
+				Assert.assertThat(
+					value,
+					hasItems(
+						_getApplicationScopeAlias(key.getKey(), scopeAlias)));
+			});
+	}
+
+	@Test
+	public void testApplicationIsolationWithScopeAliases() {
+		String[] scopes = {"everything.read", "everything.write"};
+
+		Map<String, Set<String>> applicationScopeAlias =
+			HashMapBuilder.<String, Set<String>>put(
+				"Test.Application1", Sets.newHashSet("application1.everything")
+			).put(
+				"Test.Application2", Sets.newHashSet("application2.everything")
+			).build();
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases = _exerciseBuilder(
+				builder -> applicationScopeAlias.forEach(
+					(applicationName, scopeAliases) -> builder.forApplication(
+						applicationName,
+						applicationScopeAssigner ->
+							applicationScopeAssigner.assignScope(
+								scopes
+							).mapToScopeAlias(
+								scopeAliases
+							))));
+
+		simpeEntryScopeAliases.forEach(
+			(key, value) -> {
+				Assert.assertThat(value, not(hasItems(scopes)));
+				Assert.assertEquals(
+					value, applicationScopeAlias.get(key.getKey()));
+			});
+	}
+
+	@Test
+	public void testMapToScopeAlias() {
+		String applicationName = "Test.Application";
+
+		String[] scopes = {"everything.read", "everything.write"};
+
+		String scopeAlias = "everything";
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases = _exerciseBuilder(
+				builder -> builder.forApplication(
+					applicationName,
+					applicationScopeAssigner ->
+						applicationScopeAssigner.assignScope(
+							scopes
+						).mapToScopeAlias(
+							scopeAlias
+						)));
+
+		simpeEntryScopeAliases.forEach(
+			(key, value) -> {
+				Assert.assertThat(value, not(hasItems(scopes)));
+				Assert.assertEquals(1, value.size());
+				Assert.assertThat(value, hasItems(scopeAlias));
+			});
+	}
+
+	@Test
+	public void testMultipleSeparateAssignmentsToSameScopeAlias() {
+		String applicationName = "Test.Application";
+
+		Set<String> scopes = Sets.newHashSet(
+			"everything.read", "everything.write");
+
+		Collection<String> scopeAlias = Collections.singleton("everything");
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases = _exerciseBuilder(
+				builder -> builder.forApplication(
+					applicationName,
+					applicationScopeAssigner -> {
+						applicationScopeAssigner.assignScope(
+							"everything.read"
+						).mapToScopeAlias(
+							scopeAlias
+						);
+
+						applicationScopeAssigner.assignScope(
+							"everything.write"
+						).mapToScopeAlias(
+							scopeAlias
+						);
+					}));
+
+		Assert.assertEquals(
+			simpeEntryScopeAliases.toString(), 2,
+			simpeEntryScopeAliases.size());
+
+		simpeEntryScopeAliases.forEach(
+			(key, value) -> {
+				Assert.assertEquals(scopeAlias, value);
+
+				scopes.remove(key.getValue());
+			});
+
+		Assert.assertEquals(scopes.toString(), 0, scopes.size());
+	}
+
+	@Test
+	public void testNoSpecifiedScopeAlias() {
+		String applicationName = "Test.Application";
+
+		String[] scopesArray = {"everything.read", "everything.write"};
+
+		Set<String> scopes = Sets.newHashSet(scopesArray);
+
+		// Test assigning scopes using Collection
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases1 = _exerciseBuilder(
+				builder -> builder.forApplication(
+					applicationName,
+					applicationScopeAssigner ->
+						applicationScopeAssigner.assignScope(scopes)));
+
+		// Test that the resulting scope aliases all map to all scopes
+
+		simpeEntryScopeAliases1.forEach(
+			(key, value) -> Assert.assertEquals(value, scopes));
+
+		// Repeat using VarArgs
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases2 = _exerciseBuilder(
+				builder -> builder.forApplication(
+					applicationName,
+					applicationScopeAssigner ->
+						applicationScopeAssigner.assignScope(scopesArray)));
+
+		// Assert the result is identical
+
+		Assert.assertEquals(
+			simpeEntryScopeAliases2.toString(), simpeEntryScopeAliases1.size(),
+			simpeEntryScopeAliases2.size());
+
+		Set<Map.Entry<AbstractMap.SimpleEntry<String, String>, Set<String>>>
+			entrySet = simpeEntryScopeAliases1.entrySet();
+
+		Stream<Map.Entry<AbstractMap.SimpleEntry<String, String>, Set<String>>>
+			stream = entrySet.stream();
+
+		Assert.assertTrue(
+			stream.allMatch(
+				entry -> Objects.equals(
+					entry.getValue(),
+					simpeEntryScopeAliases2.get(entry.getKey()))));
+
+		// Test separate calls result in each scope mapping to a different scope
+		// alias
+
+		simpeEntryScopeAliases1 = _exerciseBuilder(
+			builder -> builder.forApplication(
+				applicationName,
+				applicationScopeAssigner -> {
+					applicationScopeAssigner.assignScope(scopesArray[0]);
+					applicationScopeAssigner.assignScope(scopesArray[1]);
+				}));
+
+		simpeEntryScopeAliases1.forEach(
+			(key, value) -> Assert.assertEquals(
+				Collections.singleton(key.getValue()), value));
+	}
+
+	private static String _getApplicationScopeAlias(
+		String applicationName, String scope) {
+
+		return applicationName + StringPool.PERIOD + scope;
+	}
+
+	private Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+		_exerciseBuilder(Consumer<OAuth2Scope.Builder> builderConsumer) {
+
+		Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			simpleEntryScopeAliases = new HashMap<>();
+
+		OAuth2Scope.Builder builder =
+			new OAuth2ApplicationScopeAliasesLocalServiceImpl.
+				OAuth2ScopeBuilderImpl(simpleEntryScopeAliases);
+
+		builderConsumer.accept(builder);
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpleEntryScopeAliasesSet = new HashMap<>();
+
+		simpleEntryScopeAliases.forEach(
+			(key, value) -> simpleEntryScopeAliasesSet.put(
+				key, new HashSet<>(value)));
+
+		return simpleEntryScopeAliasesSet;
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
@@ -24,8 +24,7 @@ import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandlerFactory
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
-import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
-import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
+import com.liferay.oauth2.provider.service.OAuth2Scope;
 import com.liferay.oauth2.provider.shortcut.internal.constants.OAuth2ProviderShortcutConstants;
 import com.liferay.oauth2.provider.shortcut.internal.spi.scope.finder.OAuth2ProviderShortcutScopeFinder;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -106,10 +105,10 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_scopeAliasesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
+		_scopesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
 
 		for (String[] sapEntryObjectArray : _SAP_ENTRY_OBJECT_ARRAYS) {
-			_scopeAliasesList.add(
+			_scopesList.add(
 				StringUtil.replaceFirst(
 					sapEntryObjectArray[0], "OAUTH2_", StringPool.BLANK));
 		}
@@ -177,19 +176,15 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 				"https://analytics.liferay.com", 0, _APPLICATION_NAME, null,
 				Collections.singletonList(
 					"https://analytics.liferay.com/oauth/receive"),
-				_scopeAliasesList, new ServiceContext());
+				this::_buildScopes, new ServiceContext());
 
 		Class<?> clazz = getClass();
 
 		InputStream inputStream = clazz.getResourceAsStream(
 			"dependencies/logo.png");
 
-		_oAuth2ApplicationLocalService.updateIcon(
+		return _oAuth2ApplicationLocalService.updateIcon(
 			oAuth2Application.getOAuth2ApplicationId(), inputStream);
-
-		_createOAuth2ScopeGrants(oAuth2Application);
-
-		return oAuth2Application;
 	}
 
 	private void _addResourcePermissions(OAuth2Application oAuth2Application)
@@ -255,21 +250,27 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 		}
 	}
 
-	private void _createOAuth2ScopeGrants(OAuth2Application oAuth2Application)
-		throws PortalException {
+	private void _buildAnalyticsCloudScopes(OAuth2Scope.Builder builder) {
+		builder.forApplication(
+			OAuth2ProviderShortcutConstants.APPLICATION_NAME,
+			applicationScopeAssigner -> _scopesList.forEach(
+				applicationScopeAssigner::assignScope));
+	}
 
-		for (String scope : _SEGMENTS_ASAH_DEFAULT_OAUTH2_SCOPE_GRANTS) {
-			_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
-				oAuth2Application.getCompanyId(),
-				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
-				"Liferay.Segments.Asah.REST",
-				"com.liferay.segments.asah.rest.impl", scope,
-				Collections.singletonList(
-					"Liferay.Segments.Asah.REST.everything"));
-		}
+	private void _buildScopes(OAuth2Scope.Builder builder) {
+		_buildAnalyticsCloudScopes(builder);
 
-		_oAuth2ApplicationLocalService.updateOAuth2Application(
-			oAuth2Application);
+		_buildSegmentsAsahScopes(builder);
+	}
+
+	private void _buildSegmentsAsahScopes(OAuth2Scope.Builder builder) {
+		builder.forApplication(
+			"Liferay.Segments.Asah.REST",
+			applicationScopeAssigner -> applicationScopeAssigner.assignScope(
+				_SEGMENTS_ASAH_DEFAULT_OAUTH2_SCOPE_GRANTS
+			).mapToScopeAlias(
+				"Liferay.Segments.Asah.REST.everything"
+			));
 	}
 
 	private static final String _APPLICATION_NAME = "Analytics Cloud";
@@ -330,13 +331,6 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
-	private OAuth2ApplicationScopeAliasesLocalService
-		_oAuth2ApplicationScopeAliasesLocalService;
-
-	@Reference
-	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
-
-	@Reference
 	private Portal _portal;
 
 	@Reference
@@ -348,7 +342,7 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 	@Reference
 	private SAPEntryLocalService _sapEntryLocalService;
 
-	private List<String> _scopeAliasesList;
+	private List<String> _scopesList;
 	private ServiceRegistration<?> _serviceRegistration;
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
@@ -17,7 +17,6 @@ package com.liferay.oauth2.provider.shortcut.internal.instance.lifecycle;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
-import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
@@ -63,7 +62,7 @@ public class FragmentRendererPortalInstanceLifecycleListener
 
 		User user = _userLocalService.getDefaultUser(company.getCompanyId());
 
-		oAuth2Application = _oAuth2ApplicationLocalService.addOAuth2Application(
+		_oAuth2ApplicationLocalService.addOAuth2Application(
 			company.getCompanyId(), user.getUserId(), user.getScreenName(),
 			new ArrayList<GrantType>() {
 				{
@@ -73,38 +72,22 @@ public class FragmentRendererPortalInstanceLifecycleListener
 			},
 			user.getUserId(), _clientId, ClientProfile.NATIVE_APPLICATION.id(),
 			StringPool.BLANK, null, null, null, 0, _applicationName, null,
-			Collections.emptyList(), Collections.emptyList(),
+			Collections.emptyList(),
+			builder -> builder.forApplication(
+				"liferay-json-web-services",
+				scopeAssigner -> scopeAssigner.assignScope(
+					"everything.read"
+				).mapToScopeAlias(
+					"liferay-json-web-services.everything.read"
+				)),
 			new ServiceContext());
-
-		OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
-			_oAuth2ApplicationScopeAliasesLocalService.
-				addOAuth2ApplicationScopeAliases(
-					oAuth2Application.getCompanyId(),
-					oAuth2Application.getUserId(),
-					oAuth2Application.getUserName(),
-					oAuth2Application.getOAuth2ApplicationId(),
-					Collections.emptyList());
-
-		_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
-			oAuth2Application.getCompanyId(),
-			oAuth2ApplicationScopeAliases.getOAuth2ApplicationScopeAliasesId(),
-			"liferay-json-web-services", "com.liferay.oauth2.provider.jsonws",
-			"everything.read",
-			Collections.singletonList(
-				"liferay-json-web-services.everything.read"));
-
-		oAuth2Application.setOAuth2ApplicationScopeAliasesId(
-			oAuth2ApplicationScopeAliases.getOAuth2ApplicationScopeAliasesId());
-
-		_oAuth2ApplicationLocalService.updateOAuth2Application(
-			oAuth2Application);
 	}
 
 	@Activate
 	protected void activate(Map<String, Object> properties) {
+		_clientId = GetterUtil.getString(properties.get("clientId"));
 		_applicationName = GetterUtil.getString(
 			properties.get("applicationName"));
-		_clientId = GetterUtil.getString(properties.get("clientId"));
 	}
 
 	private String _applicationName = "Fragment Renderer";


### PR DESCRIPTION
Hi Tomas.
Following on from our discussion I've provided a couple of approaches to removing bundle tracking.

I think the tracking provides very little benefit because deployed code is always trusted, so why should we stop the portal admin from replacing bundles and re-mapping old authorizations?

It might have made more sense in the past when we created ScopeGrant records when handling the authorization request decision. Kind of "lock" the decision in, but see my earlier comment.

1) Completely remove it: 39b26c6
2) Leave it in LiferayOAuth2Scope (not SemVer change) and use a Supplier to resolve it on demand: 
94250a5

I'm in favor of the second approach because then we maintain a way of resolving the bundle related to ScopeFinders which might be useful in showing JAX-RS endpoints related to scopes etc. in future. Also we avoid the SemVer change.