### PR TITLE
[TS] LPS-113260 X-Forwarded-* headers & PortalImpl.getPortalURL()

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/util/LoginUtil.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/util/LoginUtil.java
@@ -210,8 +210,6 @@ public class LoginUtil {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			User.class.getName(), actionRequest);
 
-		serviceContext.setPortalURL(themeDisplay.getPortalURL());
-
 		UserLocalServiceUtil.sendPassword(
 			company.getCompanyId(), toAddress, fromName, fromAddress, subject,
 			body, serviceContext);

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/util/LoginUtil.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/util/LoginUtil.java
@@ -210,6 +210,8 @@ public class LoginUtil {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			User.class.getName(), actionRequest);
 
+		serviceContext.setPortalURL(themeDisplay.getPortalURL());
+
 		UserLocalServiceUtil.sendPassword(
 			company.getCompanyId(), toAddress, fromName, fromAddress, subject,
 			body, serviceContext);

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4121,18 +4121,12 @@ public class PortalImpl implements Portal {
 
 	@Override
 	public String getPortalURL(PortletRequest portletRequest) {
-		return getPortalURL(portletRequest, portletRequest.isSecure());
+		return getPortalURL(getHttpServletRequest(portletRequest));
 	}
 
 	@Override
 	public String getPortalURL(PortletRequest portletRequest, boolean secure) {
-		int port = portletRequest.getServerPort();
-
-		if (Validator.isNull(PropsValues.WEB_SERVER_HOST)) {
-			return _getPortalURL(portletRequest.getServerName(), port, secure);
-		}
-
-		return _getPortalURL(PropsValues.WEB_SERVER_HOST, port, secure);
+		return getPortalURL(getHttpServletRequest(portletRequest), secure);
 	}
 
 	@Override


### PR DESCRIPTION
Hi Tomas. I know that you've contributed to ```PortalImpl``` a lot and would appreciate your view on this.

```getPortalURL(PortletRequest)``` ignores portal's ```X-Forwarded-*``` normal headers support, which makes it inconsistent with its overloaded method ```getPortalURL(HttpServletRequest)``` .

Looking into Git history, this has been the case since forever!