### PR TITLE
LPS-113348 Only apply cors if OAuth2 is used

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/OAuth2ProviderScopeLiferayAccessControlContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/OAuth2ProviderScopeLiferayAccessControlContext.java
@@ -29,11 +29,18 @@ public class OAuth2ProviderScopeLiferayAccessControlContext {
 		AccessControlContext accessControlContext =
 			AccessControlUtil.getAccessControlContext();
 
+		if (accessControlContext == null) {
+			return false;
+		}
+
 		AuthVerifierResult authVerifierResult =
 			accessControlContext.getAuthVerifierResult();
 
-		if ((authVerifierResult != null) &&
-			AuthVerifierResult.State.SUCCESS.equals(
+		if (authVerifierResult == null) {
+			return false;
+		}
+
+		if (AuthVerifierResult.State.SUCCESS.equals(
 				authVerifierResult.getState())) {
 
 			String authType = MapUtil.getString(

--- a/modules/apps/portal-remote/portal-remote-cors-impl/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.http.whiteboard", version: "1.0.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-liferay-api")
 	compileOnly project(":apps:portal-remote:portal-remote-cors-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")


### PR DESCRIPTION
Hey Tomas, 
I think we discussed this already and said we wanted to document it. I was going to do it but I realized it was easy enough to directly implement it. Do you think this is what we discussed?

In order for this to work properly CORS will only be configurable on the URL's that have OAuth2 enabled already in the portal. Alas that configuration does not have a GUI. I don't know if it should in any case since the portal endpoints that should be eligible to be authorized by OAuth2 are fixed, I would say, since for extensibility we have the `/o/` path. 

Let me know what you think or forward it if you think everything is fine. 

Carlos.